### PR TITLE
.navbar-right BS3 shim should use padding-right instead of min-width

### DIFF
--- a/inst/bs3compat/_navbar_compat.scss
+++ b/inst/bs3compat/_navbar_compat.scss
@@ -18,7 +18,7 @@
 
 ul.nav.navbar-nav {
   flex: 1;
-  min-width: map-get($container-max-widths, sm) - 30px;
+  padding-right: 30px;
   &.navbar-right {
     justify-content: end;
   }


### PR DESCRIPTION
https://github.com/rstudio/rmarkdown/pull/1706#discussion_r351031941

Note also that this fixes the right navbar in the rmd website inside https://github.com/rstudio/bootsass/tree/master/test-apps/bs3-navs