### PR TITLE
Fix bug preventing JS from loading

### DIFF
--- a/R/bs_sass.R
+++ b/R/bs_sass.R
@@ -123,7 +123,7 @@ bootstrap <- function(theme = bs_theme_get(),
           content = "width=device-width, initial-scale=1, shrink-to-fit=no"
         ),
         stylesheet = output_css,
-        script = js
+        script = basename(js)
       )
     ),
     theme$html_deps


### PR DESCRIPTION
`script` is supposed to be a relative, not absolute, path