### PR TITLE
Let .btn-primary override .btn-default

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -70,6 +70,7 @@ bootstrap_javascript <- function(version, minified = TRUE) {
 bs3compat_layer <- function() {
   sass_layer(
     defaults = sass_file(system.file("bs3compat", "_pre_variables.scss", package = "bootstraplib")),
+    declarations = sass_file(system.file("bs3compat", "_declarations.scss", package = "bootstraplib")),
     rules = sass_file(system.file("bs3compat", "_post_variables.scss", package = "bootstraplib")),
     # Gyliphicon font files
     file_attachments = c(

--- a/inst/bs3compat/_declarations.scss
+++ b/inst/bs3compat/_declarations.scss
@@ -1,0 +1,23 @@
+// Restore .btn-default et al.
+// We do this in _declarations.scss instead of up in _variables.scss because
+// it's important that the `default` color come first in the $theme-colors map,
+// so .btn-default comes before .btn-primary in the generated CSS and thus has
+// lower priority.
+
+// Need to declare $default with a null value here so it has the right scope
+// (i.e. not scoped to the inside of the if/else branches)
+$default: null !default;
+
+// I don't like the default secondary color, as it's too big a departure from
+// the bootstrap 3 coloring (dark instead of light grey). But secondary is
+// semantically the closes match to default. So if secondary hasn't changed, use
+// a lighter grey for default; but if a custom secondary is in use, then use
+// that for default. (Another option would be to simply change the secondary
+// color.)
+@if $secondary == $gray-600 {
+  $default: $gray-300 !default;
+} @else {
+  $default: $secondary !default;
+}
+
+$theme-colors: map-merge(("default": $default), $theme-colors);

--- a/inst/bs3compat/_pre_variables.scss
+++ b/inst/bs3compat/_pre_variables.scss
@@ -1,7 +1,3 @@
-// Restore .btn-default
-$default: #dee2e6 !default;
-$theme-colors: () !default;
-$theme-colors: map-merge(("default": $default), $theme-colors);
 // With no Bootswatch, it makes sense to do  .navbar-default -> .navbar-light .bg-light
 //                                           .navbar-inverse -> .navbar-dark  .bg-dark
 // However, these extensions may be different for different Bootswatch themes


### PR DESCRIPTION
Example:

```
htmltools::browsable(
  htmltools::div(
    bootstraplib::bootstrap(),
    shiny::actionButton("go", "Go", class = "btn-primary")
  )
)
```

The button should be blue, not grey.