### PR TITLE
Stop write_attachment warning in bootstrap_sass

### DIFF
--- a/R/bs_sass.R
+++ b/R/bs_sass.R
@@ -143,7 +143,7 @@ bootstrap_sass <- function(rules = list(), theme = bs_theme_get(), ...) {
 
   theme <- as_bs_theme(theme)
   theme$rules <- ""
-  sass::sass(input = list(theme, rules), ...)
+  sass::sass(input = list(theme, rules), write_attachments = FALSE, ...)
 }
 
 


### PR DESCRIPTION
This fixes `write_attachment` related warnings that occur when you have a Bootswatch theme enabled and call `bootstrap_sass`.