### PR TITLE
Compatibility for columns with no row parent container

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -80,7 +80,7 @@ bs3compat_layer <- function() {
       "bs3compat", packageVersion("bootstraplib"),
       package = "bootstraplib",
       src = "bs3compat/js",
-      script = c("tabs.js", "bs3compat.js")
+      script = c("tabs.js", "bs3compat.js", "no_row_container.js")
     )
   )
 }

--- a/inst/bs3compat/_no_row_container.scss
+++ b/inst/bs3compat/_no_row_container.scss
@@ -1,0 +1,7 @@
+.no-row-container-bs3compat {
+  display: flex;
+}
+
+.tab-content > .active.no-row-container-bs3compat {
+  display: flex;
+}

--- a/inst/bs3compat/_rules.scss
+++ b/inst/bs3compat/_rules.scss
@@ -6,5 +6,7 @@
 
 @import "glyphicons";
 
+@import "no_row_container";
+
 @import "shiny_input";
 @import "shiny_misc";

--- a/inst/bs3compat/js/no_row_container.js
+++ b/inst/bs3compat/js/no_row_container.js
@@ -1,0 +1,9 @@
+// BS4 cols need their parent container to be a flex container
+// in order to render properly
+$(function() {
+  let el = $("[class*='col-sm-']").parent();
+  if (el.length === 0) return;
+  if (!el.hasClass("row")) {
+    el.addClass("row").addClass("no-row-container-bs3compat");
+  }
+});


### PR DESCRIPTION
### Minimal example:

```r
library(htmltools)
library(shiny)

browsable(fluidPage(
  div(class = "col-sm-4", "Left"),
  div(class = "col-sm-8", "Right")
))
browsable(fluidPage(
  bootstraplib::bootstrap(),
  div(class = "col-sm-4", "Left"),
  div(class = "col-sm-8", "Right")
))
```

### With side/main panel

```r
ui <- fluidPage(
  sidebarPanel(
    bootstraplib::bootstrap(),
    "Sidebar"
  ),
  mainPanel(
     "Main panel"
  )
)
shinyApp(ui = ui, server = function(input, output) {})
```

### With navs

```r
ui <- navbarPage(
  "bs3compat",
  tabPanel("Navbar 1",
           sidebarPanel(
             bootstraplib::bootstrap(),
             "sidepanel"
           ),
           mainPanel(
             tabsetPanel(
               tabPanel("Tab 1",
                        "Tab 1"
               ),
               tabPanel("Tab 2", "Tab 2"),
               tabPanel("Tab 3", "Tab 3")
             )
           )
  ),
  tabPanel("Navbar 2", "Nav 2"),
  tabPanel("Navbar 3", "Nav 3")
)

shinyApp(ui = ui, server = function(input, output) {})
```