### PR TITLE
Remove rlang walrus for static key

### DIFF
--- a/R/bs-theme.R
+++ b/R/bs-theme.R
@@ -388,7 +388,7 @@ bootswatch_bundle <- function(bootswatch, version) {
   }
 
   sass_bundle(
-    bootswatch := sass_layer(
+    bootswatch = sass_layer(
       file_attachments = attachments,
       defaults = list(
         # Use local fonts (this path is relative to the bootstrap HTML dependency dir)


### PR DESCRIPTION
Ref: https://github.com/rstudio/bslib/pull/160#discussion_r524554344

> No, this is intentional so that you can do `bs_remove(bs_theme(), "bootswatch")` and have it work regardless of the theme

Then it should be static with no walrus sign.