### PR TITLE
Make sure color-contrast() is defined before Bootswatch variables on update

### DIFF
--- a/R/bs-theme.R
+++ b/R/bs-theme.R
@@ -135,11 +135,7 @@ bs_theme <- function(version = version_default(), bootswatch = NULL, ...,
     bootswatch_bundle(bootswatch, version),
     # Always include color-contrast() so we can support bs_get_contrast()
     # for any version, and so 3rd party bslib extensions can always use it
-    sass_layer(
-      defaults = sass_file(
-        system_file("sass-utils/color-contrast.scss", package = "bslib")
-      )
-    )
+    color_contrast_layer()
   )
   bs_theme_update(
     theme, ...,
@@ -174,7 +170,7 @@ bs_theme_update <- function(theme, ..., bootswatch = NULL, bg = NULL, fg = NULL,
     }
     if (!identical(bootswatch, "default")) {
       theme <- add_class(theme, bootswatch_class(bootswatch))
-      theme <- bs_bundle(theme, bootswatch_bundle(bootswatch, theme_version(theme)))
+      theme <- bs_bundle(theme, bootswatch_bundle(bootswatch, theme_version(theme)), color_contrast_layer())
     }
   }
   # See R/bs-theme-update.R for the implementation of these
@@ -240,6 +236,18 @@ assert_bs_theme <- function(theme) {
   }
   invisible(theme)
 }
+# -----------------------------------------------------------------
+# Color contrast layer
+# -----------------------------------------------------------------
+
+color_contrast_layer <- function() {
+  sass_layer(
+    defaults = sass_file(
+      system_file("sass-utils/color-contrast.scss", package = "bslib")
+    )
+  )
+}
+
 # -----------------------------------------------------------------
 # Core Bootstrap bundle
 # -----------------------------------------------------------------

--- a/tests/testthat/test-theme-update.R
+++ b/tests/testthat/test-theme-update.R
@@ -38,11 +38,18 @@ test_that("Sass bundles work as expected with a theme", {
 test_that("bs_theme_update() can update the bootswatch theme", {
   darkly <- bs_theme(bootswatch = "darkly")
   cosmo <- bs_theme(bootswatch = "cosmo")
+
   expect_false(identical(darkly, cosmo))
   darkly2 <- bs_theme_update(cosmo, bootswatch = "darkly")
   expect_identical(
     sass::sass(darkly),
     sass::sass(darkly2)
+  )
+  cyborg <- bs_theme(bootswatch = "cyborg")
+  cyborg2 <- bs_theme_update(bs_theme(), bootswatch = "cyborg")
+  expect_identical(
+    sass::sass(cyborg),
+    sass::sass(cyborg2)
   )
   default <- bs_theme_update(cosmo, bootswatch = "default")
   expect_identical(


### PR DESCRIPTION
Follow up to #173, which introduced this new bug (and adds a test to make sure it's fixed)

```r
> sass::sass(bs_theme_update(bs_theme(), bootswatch = "cyborg"))

Error in compile_data(as_sass(input), options) : 
  Error: argument `$color` of `rgba($color, $alpha)` must be a color
        on line 67:33 of inst/lib/bootswatch/dist/cyborg/_variables.scss, in function `rgba`
        from line 67:33 of inst/lib/bootswatch/dist/cyborg/_variables.scss
        from line 7:9 of stdin
>> $table-accent-bg:               rgba($contrast-bg, .05) !default;

   --------------------------------^
```