### PR TITLE
Fix dodging for GeomErrorBar example

### DIFF
--- a/inst/themer-demo/global.R
+++ b/inst/themer-demo/global.R
@@ -54,8 +54,8 @@ ggplot2_examples <- list(
     upper = c(1.1, 5.3, 3.3, 4.2),
     lower = c(0.8, 4.6, 2.4, 3.6)
   ), aes(trt, resp, fill = group)) +
-    geom_col(position = "dodge") +
-    geom_errorbar(aes(ymin = lower, ymax = upper), position = "dodge", width = 0.25),
+    geom_col(position = position_dodge(width = 0.9)) +
+    geom_errorbar(aes(ymin = lower, ymax = upper), position = position_dodge(width = 0.9), width = 0.25),
   GeomPolygon = ggplot(values) +
     geom_map(aes(map_id = id), map = positions) +
     expand_limits(positions),


### PR DESCRIPTION
The code in the `?geom_errorbar` example is:

```R
# Because the bars and errorbars have different widths
# we need to specify how wide the objects we are dodging are
dodge <- position_dodge(width=0.9)
p +
  geom_col(position = dodge) +
  geom_errorbar(aes(ymin = lower, ymax = upper), position = dodge, width = 0.25)
```

This PR makes the code in the themer demo more like the code in the ggplot example.

Before:

![image](https://user-images.githubusercontent.com/86978/104059971-d2111080-51bb-11eb-81bc-36fa61e4a82b.png)


After:

![image](https://user-images.githubusercontent.com/86978/104059936-bf96d700-51bb-11eb-84d6-a753d3ecde48.png)
