### PR TITLE
Use `tools::R_user_dir()` when possible

### DIFF
--- a/R/fonts.R
+++ b/R/fonts.R
@@ -381,6 +381,18 @@ hash <- function(x) {
   digest::digest(x, algo = "spookyhash")
 }
 
+
+find_cache_dir <- function(pkg) {
+  # In R 4.0 and above, CRAN wants us to use the new tools::R_user_dir().
+  # If not present, fall back to rappdirs::user_cache_dir().
+  R_user_dir <- .getNamespace('tools')$R_user_dir
+  if (!is.null(R_user_dir)) {
+    R_user_dir(pkg)
+  } else {
+    rappdirs::user_cache_dir(paste0("R-", pkg))
+  }
+}
+
 # Same idea as sass::sass_cache_context_dir, but different dir
 cache_context_dir <- function(pkg = "bslib") {
   tryCatch(

--- a/R/fonts.R
+++ b/R/fonts.R
@@ -385,7 +385,7 @@ hash <- function(x) {
 find_cache_dir <- function(pkg) {
   # In R 4.0 and above, CRAN wants us to use the new tools::R_user_dir().
   # If not present, fall back to rappdirs::user_cache_dir().
-  R_user_dir <- .getNamespace('tools')$R_user_dir
+  R_user_dir <- getNamespace('tools')$R_user_dir
   if (!is.null(R_user_dir)) {
     R_user_dir(pkg)
   } else {

--- a/R/fonts.R
+++ b/R/fonts.R
@@ -398,7 +398,7 @@ cache_context_dir <- function(pkg = "bslib") {
   tryCatch(
     {
       # The usual place we'll look. This may be superseded below.
-      cache_dir <- rappdirs::user_cache_dir(paste0("R-", pkg))
+      cache_dir <- find_cache_dir(pkg)
       if (is_shiny_app()) {
         app_cache_dir <- file.path(
           shiny::getShinyOption("appDir"),

--- a/R/fonts.R
+++ b/R/fonts.R
@@ -387,7 +387,7 @@ find_cache_dir <- function(pkg) {
   # If not present, fall back to rappdirs::user_cache_dir().
   R_user_dir <- getNamespace('tools')$R_user_dir
   if (!is.null(R_user_dir)) {
-    R_user_dir(pkg)
+    R_user_dir(pkg, which = "cache")
   } else {
     rappdirs::user_cache_dir(paste0("R-", pkg))
   }


### PR DESCRIPTION
This PR addresses this comment from CRAN:


```
Also, checking creates and leaves behind
   ~/.cache/R-bslib

in violation of the CRAN Policy's

   Packages should not write in the user's home filespace (including
   clipboards), nor anywhere else on the file system apart from the R
   session's temporary directory (or during installation in the location
   pointed to by TMPDIR: and such usage should be cleaned up). Installing
   into the system's R installation (e.g., scripts to its bin directory)
   is not allowed.

   Limited exceptions may be allowed in interactive sessions if the
   package obtains confirmation from the user.

   For R version 4.0 or later (hence a version dependency is required or
   only conditional use is possible), packages may store user-specific
   data, configuration and cache files in their respective user
   directories obtained from tools::R_user_dir(), provided that by
   default sizes are kept as small as possible and the contents are
   actively managed (including removing outdated material).

Can you please change as necessary, ideally using the
tools::R_user_dir() mechanism where available?
```

When re-submitting to CRAN, it would be a good idea to mention that the behavior is fixed on R 4.0, but unchanged for older versions of R.