### PR TITLE
made sure table doesn't just grow to huge on ultra-wide displays

### DIFF
--- a/vignettes/bs4-variables.Rmd
+++ b/vignettes/bs4-variables.Rmd
@@ -173,15 +173,16 @@ table.dataTable tr td:nth-child(4){
 }
 #table-wrapper {
   position: relative;
-  width: 90vw;
-  margin-left: calc(50% - 45vw);
+  --table_w: min(90vw, 1300px);
+  width: var(--table_w);
+  margin-left: calc(50% - var(--table_w)/2);
 }
 @media (min-width: 992px) {
   #table-wrapper.pkgdown {
     /* This is 65% instead of 50% because of how pkgdown/bootstrap 
        controls widths and the center content div is 75% of its 
        container div leaving an extra 15% to take into account */
-    margin-left: calc(65% - 45vw);
+    margin-left: calc(65% - var(--table_w)/2);
   }
 }
 ```


### PR DESCRIPTION
Before the sass variables table would always be 90% of the available viewport wide. This is good until you're working on a super-wide display and the table is out-of-control. Now we max its width at `1300px` which lets all columns be seen.