### PR TITLE
Emit warning when bs_global_set() is called inside runtime: shiny 

### DIFF
--- a/R/bs-global.R
+++ b/R/bs-global.R
@@ -56,8 +56,9 @@ bs_global_set <- function(theme = bs_theme()) {
   # current theme if this code is running in an `runtime: shiny` doc
   if (is_shiny_runtime() && is_available("shiny", "1.6")) {
     warning(
-      "bs_global_set() may not work as expected inside runtime: shiny documents.",
-      "To update the document's theme, use `session$setCurrentTheme()` instead."
+      "bs_global_set() may not work as expected inside runtime: shiny documents. ",
+      "To update the document's theme, use `session$setCurrentTheme()` instead.",
+      call. = FALSE
     )
   }
   old_theme <- options(bslib_theme = theme)

--- a/R/bs-global.R
+++ b/R/bs-global.R
@@ -52,6 +52,14 @@ bs_global_set <- function(theme = bs_theme()) {
   if (!is.null(theme)) {
     assert_bs_theme(theme)
   }
+  # In addition to setting a bslib global option, also set shiny's
+  # current theme if this code is running in an `runtime: shiny` doc
+  if (is_shiny_runtime() && is_available("shiny", "1.6")) {
+    warning(
+      "bs_global_set() may not work as expected inside runtime: shiny documents.",
+      "To update the document's theme, use `session$setCurrentTheme()` instead."
+    )
+  }
   old_theme <- options(bslib_theme = theme)
   invisible(old_theme[["bslib_theme"]])
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -47,6 +47,10 @@ is_hosted_app <- function() {
   nzchar(Sys.getenv("SHINY_SERVER_VERSION")) && is_shiny_app()
 }
 
+is_shiny_runtime <- function() {
+  isTRUE(grepl("^shiny", knitr::opts_knit$get("rmarkdown.runtime")))
+}
+
 add_class <- function(x, y) {
   class(x) <- unique(c(y, oldClass(x)))
   x


### PR DESCRIPTION
And recommend using `session$setCurrentTheme()` instead. The intention is to avoid confusion when trying to do something like:

````
---
runtime: shiny
output: 
  html_document:
    theme:
      version: 4
---

```{r}
bslib::bs_global_theme_update(bg = "black", fg = "white", primary = "purple")
```

```{r}
# One might expect the slider to be purple, not blue
sliderInput("foo", "bar", 1, 3, 2)
```
````


Which works as expected without `runtime: shiny`, but inside of a shiny runtime, the more proper way to do this is to do this instead

````
---
runtime: shiny
output: 
  html_document:
    theme:
      version: 4
---

```{r, include=FALSE}
session$setCurrentTheme(bslib::bs_theme(bg = "black", fg = "white", primary = "purple"))
```

```{r}
# One might expect the slider to be purple, not blue
sliderInput("foo", "bar", 1, 3, 2)
```
````

