### PR TITLE
Allow for bootswatch='default' in bs_theme()

### DIFF
--- a/R/bs-theme.R
+++ b/R/bs-theme.R
@@ -374,7 +374,9 @@ bs3_accessibility_bundle <- function() {
 # -----------------------------------------------------------------
 
 bootswatch_bundle <- function(bootswatch, version) {
-  if (!length(bootswatch) || identical(bootswatch, "default")) return(NULL)
+  if (!length(bootswatch) || isTRUE(bootswatch %in% c("default", "bootstrap"))) {
+    return(NULL)
+  }
 
   bootswatch <- switch_version(
     version,

--- a/R/bs-theme.R
+++ b/R/bs-theme.R
@@ -374,7 +374,7 @@ bs3_accessibility_bundle <- function() {
 # -----------------------------------------------------------------
 
 bootswatch_bundle <- function(bootswatch, version) {
-  if (!length(bootswatch)) return(NULL)
+  if (!length(bootswatch) || identical(bootswatch, "default")) return(NULL)
 
   bootswatch <- switch_version(
     version,

--- a/tests/testthat/test-theme-bootswatch.R
+++ b/tests/testthat/test-theme-bootswatch.R
@@ -22,7 +22,7 @@ test_that("Can retrieve version from theme object", {
     sass::sass(bs_theme(version = "4"))
   )
 
-  # Can use default as a wat to "explicitly don't use" a Bootswatch theme
+  # Can use default as a way to "explicitly don't use" a Bootswatch theme
   default <- bs_theme(version = "4", bootswatch = "default")
   expect_equal(default, bs_theme(version = "4"), ignore_attr = TRUE)
   expect_equal(theme_bootswatch(default), "default")

--- a/tests/testthat/test-theme-bootswatch.R
+++ b/tests/testthat/test-theme-bootswatch.R
@@ -15,4 +15,15 @@ test_that("Can retrieve version from theme object", {
   expect_identical(
     theme_bootswatch(theme), "darkly"
   )
+
+  # Can use default to effectively remove bootswatch
+  expect_identical(
+    sass::sass(bs_theme_update(theme, bootswatch = "default")),
+    sass::sass(bs_theme(version = "4"))
+  )
+
+  # Can use default as a wat to "explicitly don't use" a Bootswatch theme
+  default <- bs_theme(version = "4", bootswatch = "default")
+  expect_equal(default, bs_theme(version = "4"), ignore_attr = TRUE)
+  expect_equal(theme_bootswatch(default), "default")
 })


### PR DESCRIPTION
Will be useful for https://github.com/rstudio/flexdashboard/pull/327, which wants to use Bootswatch cosmo by default
