### PR TITLE
Patch release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bslib
 Title: Custom 'Bootstrap' 'Sass' Themes for 'shiny' and 'rmarkdown'
-Version: 0.2.5.9000
+Version: 0.2.5.1
 Authors@R: c(
     person("Carson", "Sievert", role = c("aut", "cre"), email = "carson@rstudio.com", comment = c(ORCID = "0000-0002-4958-2844")),
     person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     htmltools (>= 0.5.1),
     jsonlite,
     sass (>= 0.4.0),
-    digest (>= 0.6.25),
     jquerylib (>= 0.1.3),
     rlang,
     magrittr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
-# bslib 0.2.5.9000
+# bslib 0.2.5.1
 
-
+Small patch release to fix failing test on Solaris.
 
 # bslib 0.2.5
 

--- a/tests/testthat/test-rmd-skeletons.R
+++ b/tests/testthat/test-rmd-skeletons.R
@@ -10,6 +10,10 @@ render_skeleton <- function(x) {
 }
 
 test_that("Rmd skeletons can be render cleanly", {
+  skip_if_not(
+    rmarkdown::pandoc_available("1.12.3"),
+    "Pandoc 1.12.3 or higher is required"
+  )
   expect_error(render_skeleton("bs3"), NA)
   expect_error(render_skeleton("bs4"), NA)
   withr::with_namespace(


### PR DESCRIPTION
To address BDR's email (the day after!) 0.2.5 was accepted:

```
Please see the problems shown on
<https://cran.r-project.org/web/checks/check_results_bslib.html>.

Please correct before 2021-05-27 to safely retain your package on CRAN.
```

And those problems are due to pandoc not being available on Solaris 

```
checking tests ... [67s/88s] ERROR
  Running ‘testthat.R’ [66s/87s]
Running the tests in ‘tests/testthat.R’ failed.
Complete output:
  > library(testthat)
  > library(bslib)
  >
  > test_check("bslib")
  ══ Skipped tests ═══════════════════════════════════════════════════════════════
  • On CRAN (3)
  
  ══ Failed tests ════════════════════════════════════════════════════════════════
  ── Failure (test-rmd-skeletons.R:13:3): Rmd skeletons can be render cleanly ────
  `render_skeleton("bs3")` threw an unexpected error.
  Message: pandoc version 1.12.3 or higher is required and was not found (see the help page ?rmarkdown::pandoc_available).
  Class: simpleError/error/condition
  Backtrace:
      █
   1. ├─testthat::expect_error(render_skeleton("bs3"), NA) test-rmd-skeletons.R:13:2
   2. │ └─testthat:::expect_condition_matching(...)
   3. │ └─testthat:::quasi_capture(...)
   4. │ ├─testthat:::.capture(...)
   5. │ │ └─base::withCallingHandlers(...)
   6. │ └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
   7. └─bslib:::render_skeleton("bs3")
   8. └─rmarkdown::render(file.path(tmp, "tmp.Rmd"), quiet = TRUE) test-rmd-skeletons.R:9:2
   9. └─rmarkdown::pandoc_available(required_pandoc, error = TRUE)
  ── Failure (test-rmd-skeletons.R:14:3): Rmd skeletons can be render cleanly ────
  `render_skeleton("bs4")` threw an unexpected error.
  Message: pandoc version 1.12.3 or higher is required and was not found (see the help page ?rmarkdown::pandoc_available).
  Class: simpleError/error/condition
  Backtrace:
      █
   1. ├─testthat::expect_error(render_skeleton("bs4"), NA) test-rmd-skeletons.R:14:2
   2. │ └─testthat:::expect_condition_matching(...)
   3. │ └─testthat:::quasi_capture(...)
   4. │ ├─testthat:::.capture(...)
   5. │ │ └─base::withCallingHandlers(...)
   6. │ └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
   7. └─bslib:::render_skeleton("bs4")
   8. └─rmarkdown::render(file.path(tmp, "tmp.Rmd"), quiet = TRUE) test-rmd-skeletons.R:9:2
   9. └─rmarkdown::pandoc_available(required_pandoc, error = TRUE)
  ── Failure (test-rmd-skeletons.R:15:3): Rmd skeletons can be render cleanly ────
  `render_skeleton("real-time")` threw an unexpected error.
  Message: pandoc version 1.12.3 or higher is required and was not found (see the help page ?rmarkdown::pandoc_available).
  Class: simpleError/error/condition
  Backtrace:
       █
    1. ├─withr::with_namespace(...) test-rmd-skeletons.R:15:2
    2. │ └─base::force(code)
    3. ├─testthat::expect_error(render_skeleton("real-time"), NA)
    4. │ └─testthat:::expect_condition_matching(...)
    5. │ └─testthat:::quasi_capture(...)
    6. │ ├─testthat:::.capture(...)
    7. │ │ └─base::withCallingHandlers(...)
    8. │ └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
    9. └─bslib:::render_skeleton("real-time")
   10. └─rmarkdown::render(file.path(tmp, "tmp.Rmd"), quiet = TRUE) test-rmd-skeletons.R:9:2
   11. └─rmarkdown::pandoc_available(required_pandoc, error = TRUE)
  
  [ FAIL 3 | WARN 0 | SKIP 3 | PASS 185 ]
````