### PR TITLE
Fix bs_get_contrast() when in shiny devmode

### DIFF
--- a/R/bs-theme-preview.R
+++ b/R/bs-theme-preview.R
@@ -696,7 +696,10 @@ bs_get_contrast <- function(theme, varnames) {
   )
   css <- sass::sass_partial(
     paste0("bs_get_contrast {", prop_string, "}"),
-    theme, cache_key_extra = packageVersion("bslib")
+    theme, cache_key_extra = packageVersion("bslib"),
+    # Don't listen to global Sass options so we can be sure
+    # that stuff like source maps won't be included
+    options = sass::sass_options(source_map_embed = FALSE)
   )
   css <- gsub("\n", "", gsub("\\s*", "", css))
   css <- sub("bs_get_contrast{", "", css, fixed = TRUE)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -64,7 +64,7 @@ reference:
     Tools for creating and dynamically updating navs.
   contents:
     - nav
-    - navs
+    - navs_tab
     - nav_select
 - title: Create a Bootstrap page
   contents:


### PR DESCRIPTION
Closes #321. Introduced by #312 (now when in devmode, source maps are included and the existing `bs_get_contrast()` algorithm doesn't account for that).