### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/tests/testthat/test-theme-base-colors.R
+++ b/tests/testthat/test-theme-base-colors.R
@@ -51,8 +51,8 @@ test_that("bs3 base colors", {
       `brand-primary` = "#0000FF")
   )
 
-  theme <- expect_warning(
-    bs_theme("3", bg = "#112233", fg = "#FFEEDD", primary = "orange", secondary = "brown"),
+  expect_warning(
+    theme <- bs_theme("3", bg = "#112233", fg = "#FFEEDD", primary = "orange", secondary = "brown"),
     "doesn't support.*ignored"
   )
   colors <- bs_get_variables(theme, varnames)
@@ -109,9 +109,9 @@ test_that("bs3 accent colors", {
       `brand-danger` = "#d9534f")
   )
 
-  theme <- expect_warning(
-    bs_theme("3", primary = "#123", secondary = "#234",
-             success = "#345", info = "#456", warning = "#567", danger = "#678"),
+  expect_warning(
+    theme <- bs_theme("3", primary = "#123", secondary = "#234",
+                      success = "#345", info = "#456", warning = "#567", danger = "#678"),
     "doesn't support"
   )
   expect_identical(bs_get_variables(theme, varnames),


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.
