### PR TITLE
Revert to pre-Bootstrap 5 nav bs3compat shimming

### DIFF
--- a/inst/bs3compat/js/bs3compat.js
+++ b/inst/bs3compat/js/bs3compat.js
@@ -22,9 +22,9 @@ $(function() {
   // Re-define the tab click event
   // https://github.com/twbs/bootstrap/blob/08139c2/js/src/tab.js#L33
   var EVENT_KEY = "click.bs.tab.data-api";
-  var SELECTOR = '[data-toggle="tab"], [data-toggle="pill"], [data-bs-toggle="tab"], [data-bs-toggle="pill"]';
-
   $(document).off(EVENT_KEY);
+
+  var SELECTOR = '[data-toggle="tab"], [data-toggle="pill"], [data-bs-toggle="tab"], [data-bs-toggle="pill"]';
   $(document).on(EVENT_KEY, SELECTOR, function(event) {
     event.preventDefault();
     $(this).tab("show");

--- a/inst/bs3compat/js/bs3compat.js
+++ b/inst/bs3compat/js/bs3compat.js
@@ -12,28 +12,37 @@ $(function() {
     (console.warn || console.error || console.log)("bs3compat.js couldn't find bs3 tab impl; bs3 tabs will not be properly supported");
     return;
   }
+  var legacyTabPlugin = $.fn.tab.noConflict();
+
+  if (!$.fn.tab || !$.fn.tab.Constructor || !$.fn.tab.noConflict) {
+    (console.warn || console.error || console.log)("bs3compat.js couldn't find a jQuery tab impl; bs3 tabs will not be properly supported");
+  }
+  var newTabPlugin = $.fn.tab.noConflict();
 
   // Re-define the tab click event
   // https://github.com/twbs/bootstrap/blob/08139c2/js/src/tab.js#L33
   var EVENT_KEY = "click.bs.tab.data-api";
-  $(document).off(EVENT_KEY);
-
   var SELECTOR = '[data-toggle="tab"], [data-toggle="pill"], [data-bs-toggle="tab"], [data-bs-toggle="pill"]';
+
+  $(document).off(EVENT_KEY);
   $(document).on(EVENT_KEY, SELECTOR, function(event) {
     event.preventDefault();
-
-    // Legacy (bs3) tabs: li.active > a
-    // New (bs4+) tabs: li.nav-item > a.active.nav-link
-    var $el = $(event.target);
-    var legacy = $el.closest(".nav").find("li:not(.dropdown).active > a").length > 0;
-
-    if (legacy) {
-      $el.tab("show");
-    } else {
-      var tab = new bootstrap.Tab($el[0]);
-      tab.show();
-    }
-
+    $(this).tab("show");
   });
 
+  function TabPlugin(config) {
+    // Legacy (bs3) tabs: li.active > a
+    // New (bs4+) tabs: li.nav-item > a.active.nav-link
+    var legacy = $(this).closest(".nav").find("li:not(.dropdown).active > a").length > 0;
+    var plugin = legacy ? legacyTabPlugin : newTabPlugin;
+    plugin.call($(this), config);
+  }
+
+  var noconflict = $.fn.tab;
+  $.fn.tab = TabPlugin;
+  $.fn.tab.Constructor = newTabPlugin.Constructor;
+  $.fn.tab.noConflict = function() {
+    $.fn.tab = noconflict;
+    return TabPlugin;
+  };
 });


### PR DESCRIPTION
In #304, I changed the overall approach to shimming Bootstrap's `$.fn.tab` jQuery plugin (I wanted to move away from assuming that it exists), but that approach won't work when tabs are shown programmatically (e.g., `shinycoreci-apps/apps/213-tab-panels`). 

This reverts it to use the same `.noConflict()` approach we were using before in a way that works for Bootstrap 5. Originally, I thought that this approach wasn't going to work at all because Bootstrap 5 doesn't register this plugin until the DOM is ready, but now that we execute this code after the DOM is ready, this approach seems to work fine. 