### PR TITLE
v0.3.2 release candidate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bslib
 Title: Custom 'Bootstrap' 'Sass' Themes for 'shiny' and 'rmarkdown'
-Version: 0.3.1.9000
+Version: 0.3.2
 Authors@R: c(
     person("Carson", "Sievert", role = c("aut", "cre"), email = "carson@rstudio.com", comment = c(ORCID = "0000-0002-4958-2844")),
     person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,7 @@
-# bslib 0.3.1.9000
+# bslib 0.3.2
 
 ## Breaking changes
 
-* `bs_theme()` now defaults to `version = 5` (i.e., Bootstrap 5). If this change happens to break an existing app, consider specifying `bs_theme(version = 4)` to revert the change in the Bootstrap version. (#374)
 * The default coloring on some Bootswatch 4+ theme's `.navbar-default`/`.navbar-inverse` class has changed slightly to better match their Bootswatch 3 coloring. Also, since this coloring is now based solely on [`$navbar-*` variables](https://rstudio.github.io/bslib/articles/bs5-variables.html), Bootswatch themes now work better in combination with custom `$navbar-*` values (e.g., `bs_theme("navbar-bg" = ...)` can be used to provide the background color, and foreground colors will automatically contrast appropriately). (#392)
 
 ## New features

--- a/R/version-default.R
+++ b/R/version-default.R
@@ -13,7 +13,7 @@ versions <- function() {
 #' @export
 #' @rdname versions
 version_default <- function() {
-  versions()[[1]]
+  versions()[[2]]
 }
 
 # TODO: make this a getter/setter?

--- a/README.Rmd
+++ b/README.Rmd
@@ -67,13 +67,13 @@ install.packages("rmarkdown")
 
 `bslib` is designed for use with any Shiny or R Markdown project that uses Bootstrap. In most cases, you can identify a project that uses Bootstrap when the relevant page constructor has a `theme` parameter. For example, most Shiny page layout functions (e.g., `shiny::navbarPage()`) and some popular R Markdown formats (e.g., `rmarkdown::html_document`) all have a `theme` parameter.
 
-To use `bslib` in Shiny, provide a `bs_theme()` _object_ to the `theme` parameter; and in R Markdown, provide `bs_theme()` _parameters_ to `theme`. For example, here's a way to upgrade Shiny (left) and R Markdown (right) from Bootstrap 3 to 5:
+To use `bslib` in Shiny, provide a `bs_theme()` _object_ to the `theme` parameter; and in R Markdown, provide `bs_theme()` _parameters_ to `theme`. For example, here's a way to upgrade Shiny (left) and R Markdown (right) from Bootstrap 3 to 4:
 
 <div class="usage">
 ```r
 library(shiny)
 ui <- navbarPage(
-  theme = bs_theme(version = 5),
+  theme = bs_theme(version = 4),
   ...
 )
 shinyApp(ui, function(...) {})
@@ -83,7 +83,7 @@ shinyApp(ui, function(...) {})
 output:
   html_document:
     theme:
-      version: 5
+      version: 4
 ---
 ```
 </div>

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,8 +40,8 @@ The `bslib` R package provides tools for customizing [Bootstrap themes](https://
 * Also provide easy access to pre-packaged [Bootswatch themes](https://rstudio.github.io/bslib/articles/bslib.html#bootswatch).
 * Make [upgrading from Bootstrap 3 to 4 (and beyond)](https://rstudio.github.io/bslib/articles/bslib.html#versions) as seamless as possible.
   * Shiny and R Markdown default to Bootstrap 3 and will continue to do so to avoid breaking legacy code.
-* Serve as a general foundation for Shiny and R Markdown extension packages.
-  * Extensions such as [`flexdashboard`](https://flexdashboard-pkg.netlify.app/articles/theme.html), [`pkgdown`](https://pkgdown.r-lib.org/dev/articles/customization.html), and [`bookdown`](https://pkgs.rstudio.com/bookdown/reference/bs4_book.html) already fully support [`bslib`'s custom theming capabilities](https://rstudio.github.io/bslib/articles/bslib.html#custom).
+* Serve as a general foundation for Shiny and R Markdown extension packages. 
+  * Extensions such as [`flexdashboard`](https://flexdashboard-pkg.netlify.app/articles/theme.html), [`pkgdown`](https://pkgdown.r-lib.org/dev/articles/customise.html), and [`bookdown`](https://pkgs.rstudio.com/bookdown/reference/bs4_book.html) already fully support [`bslib`'s custom theming capabilities](https://rstudio.github.io/bslib/articles/bslib.html#custom).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ For example, most Shiny page layout functions (e.g.,
 To use `bslib` in Shiny, provide a `bs_theme()` *object* to the `theme`
 parameter; and in R Markdown, provide `bs_theme()` *parameters* to
 `theme`. For example, here’s a way to upgrade Shiny (left) and R
-Markdown (right) from Bootstrap 3 to 5:
+Markdown (right) from Bootstrap 3 to 4:
 
 <div class="usage">
 
 ``` r
 library(shiny)
 ui <- navbarPage(
-  theme = bs_theme(version = 5),
+  theme = bs_theme(version = 4),
   ...
 )
 shinyApp(ui, function(...) {})
@@ -95,7 +95,7 @@ shinyApp(ui, function(...) {})
 output:
   html_document:
     theme:
-      version: 5
+      version: 4
 ---
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ goals are:
     packages.
       - Extensions such as
         [`flexdashboard`](https://flexdashboard-pkg.netlify.app/articles/theme.html),
-        [`pkgdown`](https://pkgdown.r-lib.org/dev/articles/customization.html),
+        [`pkgdown`](https://pkgdown.r-lib.org/dev/articles/customise.html),
         and
         [`bookdown`](https://pkgs.rstudio.com/bookdown/reference/bs4_book.html)
         already fully support [`bslib`’s custom theming


### PR DESCRIPTION
Note that this reverts 0b7ffb221ad52f84f700fc36dae142efeca9bfcd

After release+merge of this PR (v0.3.2), I'll cherry-pick that commit back into main so that the dev version will continue defaulting to Bootstrap 5 (and the next release of bslib (v0.4.0) will default to Bootstrap 5)