### PR TITLE
Have bs3compat's tab shim search for BS4+ style markup first

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Suggests:
     magrittr
 License: MIT + file LICENSE
 Encoding: UTF-8
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Roxygen: list(markdown = TRUE)
 Collate:
     'bootswatch.R'

--- a/inst/bs3compat/js/bs3compat.js
+++ b/inst/bs3compat/js/bs3compat.js
@@ -33,8 +33,8 @@ $(function() {
   function TabPlugin(config) {
     // Legacy (bs3) tabs: li.active > a
     // New (bs4+) tabs: li.nav-item > a.active.nav-link
-    var legacy = $(this).closest(".nav").find("li:not(.dropdown).active > a").length > 0;
-    var plugin = legacy ? legacyTabPlugin : newTabPlugin;
+    var legacy = $(this).closest(".nav").find("li:not(.dropdown) > a.active").length > 0;
+    var plugin = legacy ? newTabPlugin : legacyTabPlugin;
     plugin.call($(this), config);
   }
 

--- a/man/bs_theme.Rd
+++ b/man/bs_theme.Rd
@@ -138,15 +138,19 @@ character vector can have:
 
 Since \code{font_google(..., local = TRUE)} guarantees that the client has access to
 the font family, meaning it's relatively safe to specify just one font
-family, for instance:\preformatted{bs_theme(base_font = font_google("Pacifico", local = TRUE))
-}
+family, for instance:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{bs_theme(base_font = font_google("Pacifico", local = TRUE))
+}\if{html}{\out{</div>}}
 
 However, specifying multiple "fallback" font families is recommended,
 especially when relying on remote and/or system fonts being available, for
 instance. Fallback fonts are useful not only for handling missing fonts, but
 also for handling a Flash of Invisible Text (FOIT) which can be quite
-noticeable with remote web fonts on a slow internet connection.\preformatted{bs_theme(base_font = font_collection(font_google("Pacifico", local = FALSE), "Roboto", "sans-serif"))
-}
+noticeable with remote web fonts on a slow internet connection.
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{bs_theme(base_font = font_collection(font_google("Pacifico", local = FALSE), "Roboto", "sans-serif"))
+}\if{html}{\out{</div>}}
 }
 
 \examples{


### PR DESCRIPTION
Close #415

TODO: verify this fixes both BS4 and BS5 using the example in #415