### PR TITLE
More carefully mark nav_menu() as active across Bootstrap versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Closed #393: Bootstrap 5's `$form-check-label-*` variables now work as expected with `shiny::radioButtons()`, `shiny::checkboxInput()`, and `shiny::checkboxGroupInput()`. (#395)
 * Closed #382: Various fixes for using `shiny::checkboxInput()`, `shiny::checkboxGroupInput()`, and `shiny::radioButton()` with `bs_theme(version = 5, bootswatch = "sketchy")`. (#385)
 * Closed #377: make sure `shiny::tabsetPanel(type = "hidden")` (i.e., `bslib::navs_hidden()`) stays hidden when used with `bs_theme()`. (#379)
+* Closed #424: fixed an issue with `nav_menu()` appearing first in a `navs_*()` container with Bootstrap 4+.
 * Closed #400: `nav_menu(align="right")` now works with Bootstrap 5. (#401)
 * Closed #390: using `bs_theme(bootswatch = "paper", version = 5)` or `bs_theme(bootswatch = "readable", version = 5)` no longer errors. (#391)
 

--- a/R/navs-legacy.R
+++ b/R/navs-legacy.R
@@ -584,7 +584,6 @@ buildDropdown <- function(divTag, tabset) {
 
   dropdown <- tags$li(
     class = "dropdown",
-    class = if (active) "active",
     tags$a(
       href = "#",
       class = "dropdown-toggle",
@@ -603,9 +602,10 @@ buildDropdown <- function(divTag, tabset) {
           addClass("nav-item")$
           find(".dropdown-toggle")$
           addClass("nav-link")$
+          addClass(if (active) "active")$
           allTags()
       } else {
-        x
+        tagAppendAttributes(x, class = if (active) "active")
       }
     }
   )


### PR DESCRIPTION
Closes #423

## Testing notes

First run the following app. Note that if you click "B" (to show "b"), you can't click "Menu" -> "A" (to show "a")

```r
library(shiny)
library(bslib)

ui <- navbarPage(
  theme = bs_theme(version = 5),
  title = "reprex",
  navbarMenu("Menu", tabPanel("A", "a")),
  tabPanel("B", "b")
)

shinyApp(ui, function(...) {})
```

Now install `remotes::install_github("rstudio/bslib")` and re-run the app. Verify that you're able to click "B"  (to show "b") and then click "Menu" -> "A" (to show "a")