### PR TITLE
Adjust sidebar function signature and require `sidebar` argument

### DIFF
--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -30,9 +30,16 @@
 #' @param class Additional CSS classes for the top-level HTML element.
 #'
 #' @export
-sidebar <- function(..., width = 250, position = c("left", "right"), open = TRUE, id = NULL, bg = NULL, class = NULL) {
-
-  # For accessiblity reasons, always provide id when collapsible,
+sidebar <- function(
+  ...,
+  width = 250,
+  position = c("left", "right"),
+  open = TRUE,
+  id = NULL,
+  bg = NULL,
+  class = NULL
+) {
+  # For accessibility reasons, always provide id when collapsible,
   # but only create input binding when id is provided
   if (is.null(id) && is.logical(open)) {
     id <- paste0("bslib-sidebar-", p_randomInt(1000, 10000))
@@ -83,8 +90,16 @@ sidebar <- function(..., width = 250, position = c("left", "right"), open = TRUE
 #' @inheritParams card
 #'
 #' @export
-layout_sidebar <- function(sidebar = sidebar(), ..., fillable = FALSE, fill = TRUE, bg = NULL, border = TRUE, border_radius = TRUE, height = NULL) {
-
+layout_sidebar <- function(
+  sidebar = sidebar(),
+  ...,
+  fillable = FALSE,
+  fill = TRUE,
+  bg = NULL,
+  border = TRUE,
+  border_radius = TRUE,
+  height = NULL
+) {
   if (!inherits(sidebar, "sidebar")) {
     abort("`sidebar` argument must contain a `bslib::sidebar()` component.")
   }

--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -91,7 +91,7 @@ sidebar <- function(
 #'
 #' @export
 layout_sidebar <- function(
-  sidebar = sidebar(),
+  sidebar,
   ...,
   fillable = FALSE,
   fill = TRUE,

--- a/man/sidebar.Rd
+++ b/man/sidebar.Rd
@@ -18,7 +18,7 @@ sidebar(
 )
 
 layout_sidebar(
-  sidebar = sidebar(),
+  sidebar,
   ...,
   fillable = FALSE,
   fill = TRUE,


### PR DESCRIPTION
This is prequel to a series of sidebar-related PRs. Mostly, this PR adjusts the code style of the function signatures of `layout_sidebar()` and `sidebar()` so arguments appear on their own line, which will reduce merge conflicts and dependences between the rest of the PRs I'm extracting from #516.