### PR TITLE
Fix scss for `sidebar(open="desktop")`

### DIFF
--- a/inst/components/sidebar.scss
+++ b/inst/components/sidebar.scss
@@ -240,7 +240,7 @@ $bslib-sidebar-column-main: minmax(0, 1fr);
     --bslib-collapse-toggle-right-transform: -180deg;
 
     // required by sidebar init js when `sidebar(open = "desktop")`
-    &[data-sidebar-init-auto-collapse] {
+    &[data-bslib-sidebar-open="desktop"] {
       --bslib-sidebar-js-init-collapsed: true;
     }
 


### PR DESCRIPTION
A small follow up to #517 to fix a change in selector name in the scss.