### PR TITLE
Remove extra fenced div delimiters

### DIFF
--- a/vignettes/sidebars.Rmd
+++ b/vignettes/sidebars.Rmd
@@ -528,8 +528,6 @@ $('#nav').on('shown.bs.tab', function(ev) {
 ```
 :::
 ::::
-:::
-::::
 
 
 ### Reactive updates


### PR DESCRIPTION
Small edit to sidebars article to remove unnecessary fenced div markers