### PR TITLE
Sidebar color CSS vars and defaults

### DIFF
--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -104,10 +104,6 @@ sidebar <- function(
         class = "collapse-toggle",
         type = "button",
         title = "Toggle sidebar",
-        style = css(
-          background_color = bg,
-          color = fg
-        ),
         "aria-expanded" = if (open %in% c("open", "desktop")) "true" else "false",
         "aria-controls" = id,
         collapse_icon()
@@ -120,7 +116,6 @@ sidebar <- function(
       role = "complementary",
       class = c("sidebar", class),
       hidden = if (open == "closed") NA,
-      style = css(background_color = bg, color = fg),
       tags$div(
         class = "sidebar-content",
         title,
@@ -131,7 +126,8 @@ sidebar <- function(
     position = match.arg(position),
     open = open,
     width = validateCssUnit(width),
-    max_height_mobile = validateCssUnit(max_height_mobile)
+    max_height_mobile = validateCssUnit(max_height_mobile),
+    color = list(bg = bg, fg = fg)
   )
 
   class(res) <- c("sidebar", class(res))
@@ -214,6 +210,8 @@ layout_sidebar <- function(
     `data-bslib-sidebar-border-radius` = if (!is.null(border_radius)) tolower(border_radius),
     style = css(
       "--bslib-sidebar-width" = sidebar$width,
+      "--bslib-sidebar-bg" = if (!is.null(sidebar$color$bg)) sidebar$color$bg,
+      "--bslib-sidebar-fg" = if (!is.null(sidebar$color$fg)) sidebar$color$fg,
       "--bs-card-border-color" = border_color,
       height = validateCssUnit(height),
       "--bslib-sidebar-max-height-mobile" = max_height_mobile

--- a/inst/components/sidebar.scss
+++ b/inst/components/sidebar.scss
@@ -12,6 +12,8 @@ $bslib-sidebar-column-main: minmax(0, 1fr);
   --bslib-sidebar-border: #{$bslib-sidebar-border};
   --bslib-sidebar-border-radius: var(--bs-border-radius);
   --bslib-sidebar-vert-border: #{$bslib-sidebar-border};
+  --bslib-sidebar-bg: #{$bslib-sidebar-bg};
+  --bslib-sidebar-fg: #{$bslib-sidebar-fg};
   --bslib-collapse-toggle-border: #{$bslib-sidebar-border};
   --bslib-collapse-toggle-transform: 90deg;
   --bslib-collapse-toggle-right-transform: -90deg;
@@ -52,8 +54,8 @@ $bslib-sidebar-column-main: minmax(0, 1fr);
     border-right: var(--bslib-sidebar-vert-border);
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
-    background-color: $bslib-sidebar-bg;
-    color: $bslib-sidebar-fg;
+    background-color: var(--bslib-sidebar-bg);
+    color: var(--bslib-sidebar-fg);
 
     > .sidebar-content {
       display: flex;
@@ -129,8 +131,8 @@ $bslib-sidebar-column-main: minmax(0, 1fr);
     border-left: none;
     border-radius: 0 var(--bs-border-radius) var(--bs-border-radius) 0;
     padding: 7px 0;
-    background-color: $bslib-sidebar-bg;
-    color: $bslib-sidebar-fg;
+    background-color: var(--bslib-sidebar-bg);
+    color: var(--bslib-sidebar-fg);
 
     > .collapse-icon {
       opacity: 0.8;

--- a/inst/components/sidebar.scss
+++ b/inst/components/sidebar.scss
@@ -1,6 +1,6 @@
 $bslib-sidebar-padding: $spacer * 1.5 !default;
 $bslib-sidebar-icon-size: $spacer !default;
-$bslib-sidebar-bg: $gray-100 !default;
+$bslib-sidebar-bg: mix($body-color, $body-bg, 3.66%) !default;
 $bslib-sidebar-fg: color-contrast($bslib-sidebar-bg) !default;
 $bslib-sidebar-border: var(--bs-card-border-width, #{$card-border-width}) solid var(--bs-card-border-color, #{$card-border-color}) !default;
 $bslib-sidebar-transition-duration: 500ms !default;


### PR DESCRIPTION
Fixes #551

## CSS Variables

The biggest part of this PR is that we now use CSS variables to set the sidebar background color. We add `--bslib-sidebar-bg` and `--bslib-sidebar-fg` by default to `.bsib-sidebar-layout`. Both `> .sidebar` and `> .collapse-toggle` will pick up their background color from these CSS variables. This means that the sidebar and toggle colors can be set with one rule applied to `.bslib-sidebar-layout`.

Internally, when `bg` or `fg` are set in `sidebar()`, we now pass that information up to `layout_sidebar()` and set those CSS variables in a `style` argument for that specific layout.

## New Background Color Default

The other change made here is to choose a default sidebar color that more closely matches the typical card-header background and that will be appropriately dark when used in a dark theme. Previously we used `$gray-100`, which looks great in the default BS theme, but for dark themes `$gray-100` is still a very light color.

The challenge here is that the card header background color is set via `$card-cap-bg` and typically defaults to an `rgba()` color (`rgba(0,0,0,0.3)` to be specific). We need an opaque color without an alpha channel for `color-contrast()` to work as expected, and also because the collapse toggle expects to obscure the sidebar border.

A mix of 3.66% results in a color blend that matches the percieved default color and works in most cases. I tested this with all of the bootswatch themes and in generally it's an improvement, although in the future we may want to patch specific themes.