### PR TITLE
Set `role="heading"` for header of sidebar

### DIFF
--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -95,7 +95,7 @@ sidebar <- function(
   }
 
   if (rlang::is_bare_character(title) || rlang::is_bare_numeric(title)) {
-    title <- div(title, class = "sidebar-title" role="heading")
+    title <- div(title, class = "sidebar-title", role="heading")
   }
 
   collapse_tag <-

--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -95,7 +95,7 @@ sidebar <- function(
   }
 
   if (rlang::is_bare_character(title) || rlang::is_bare_numeric(title)) {
-    title <- div(title, class = "sidebar-title")
+    title <- div(title, class = "sidebar-title" role="heading")
   }
 
   collapse_tag <-


### PR DESCRIPTION
This is a minimum fix for the accessibility of the sidebar title. 

By using `role="heading"` we are effectively making the title-containing `div` look like an `h2` tag (see [implicit `aria-level`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/heading_role#associated_wai-aria_roles_states_and_properties)). 

I think it [_may_ be better to use an `h2` tag](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/heading_role#best_practices) as we get predictable sizing and also more semantic HTML. While, in theory, a page could have a lot of nested sidebars, and this would be confusing, screen-readers seem to handle it fine. 


