### PR TITLE
Attempt to fix deploys

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -114,6 +114,7 @@ Config/Needs/deploy:
     ggplot2,
     hexbin,
     lattice,
+    plotly,
     reactable,
     rprojroot,
     rsconnect


### PR DESCRIPTION
Seems like plotly might need to be listed in deploys (since several of the deployed apps use it)? Won't actually know if this fixes deploys until we merge 

https://github.com/rstudio/bslib/actions/runs/4949243116/jobs/8851386492#step:6:34