### PR TITLE
Fix `NULL` caller function environment

### DIFF
--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -164,7 +164,7 @@ deprecate_if_not_called_from_shiny <- function(old_name, new, version) {
 
   function(...) {
     caller_fn_env <- environment(rlang::caller_fn())
-    if (!is.null(caller_fn_env) && rlang::is_environment(caller_fn_env))) {
+    if (!is.null(caller_fn_env) && rlang::is_environment(caller_fn_env)) {
       caller_fn_env <- rlang::env_name(caller_fn_env)
     }
     if (!identical(caller_fn_env, "namespace:shiny")) {

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -164,7 +164,7 @@ deprecate_if_not_called_from_shiny <- function(old_name, new, version) {
 
   function(...) {
     caller_fn_env <- environment(rlang::caller_fn())
-    if (!is.null(caller_fn_env)) {
+    if (!is.null(caller_fn_env) && rlang::is_environment(caller_fn_env))) {
       caller_fn_env <- rlang::env_name(caller_fn_env)
     }
     if (!identical(caller_fn_env, "namespace:shiny")) {

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -164,7 +164,10 @@ deprecate_if_not_called_from_shiny <- function(old_name, new, version) {
 
   function(...) {
     caller_fn_env <- environment(rlang::caller_fn())
-    if (!identical(rlang::env_name(caller_fn_env), "namespace:shiny")) {
+    if (!is.null(caller_fn_env)) {
+      caller_fn_env <- rlang::env_name(caller_fn_env)
+    }
+    if (!identical(caller_fn_env, "namespace:shiny")) {
       msg <- sprintf(
         "`%s()` was deprecated in {bslib} version %s, use `%s()` instead.",
         old_name, version, new_name


### PR DESCRIPTION
There was a small bug in #546 that would manifest when running an app via `shiny::runApp()`.

When the following app is run via `shiny::runApp()`

```r
library(shiny)
library(bslib)

ui <- fluidPage(
  navs_bar(nav("Foo", "foo"))
)

shinyApp(ui, function(...) { })
```

it will currently generate an error

```
Error in `rlang::env_name()`:
! `env` must be an environment, not `NULL`.
```

due to `runApp()`'s use of `eval()`. This PR catches the case of the calling function's environment being `NULL` and assumes that means the function is not being called from within Shiny. With this PR, when you exit the app, the expected deprecation warnings are printed.

You can replace `navs_bar()` with `tabsetPanel()` to verify that the deprecation warnings are appropriately muffled in `tabsetPanel()`.

```r
library(shiny)
library(bslib)

ui <- fluidPage(
  # navs_bar(nav("Foo", "foo"))
  tabsetPanel(
    tabPanel("Foo", "foo")
  )
)

shinyApp(ui, function(...) { })
```

(If testing, be sure to run via `shiny::runApp()`.)