### PR TITLE
Have themer-demo continue to default to inverse = FALSE

### DIFF
--- a/inst/themer-demo/app.R
+++ b/inst/themer-demo/app.R
@@ -77,6 +77,7 @@ shinyApp(
     theme = theme,
     title = "Theme demo",
     collapsible = TRUE,
+    inverse = FALSE,
     id = "navbar",
     fillable = "Dashboard",
     dashboardTab,


### PR DESCRIPTION
In https://github.com/rstudio/bslib/pull/572/files, we switched from `navbarPage()` to `page_navbar()`, which changed the default `inverse` from `F` to `T`. This changes it back to `F` so that we don't have to change/update `301` or `302` tests https://rstudio.github.io/shinycoreci/results/2023/05/18/ 