### PR TITLE
Only undo p/pre/input margin-bottom spacing when a _direct_ child of gap spacing

### DIFF
--- a/inst/components/fill.scss
+++ b/inst/components/fill.scss
@@ -59,7 +59,7 @@
 // Our own utility class that we add to our layout utilities, like page_fillable().
 .bslib-gap-spacing {
   gap: var(--bslib-mb-spacer);
-  > .bslib-mb-spacer, .form-group, p, pre {
+  > .bslib-mb-spacer, > .form-group, > p, > pre {
     margin-bottom: 0;
   }
 }


### PR DESCRIPTION
(which should've been done in #599 and #601)
