### PR TITLE
Don't call `shiny::restoreInput()` inside `accordion()` if id isn't provided

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # bslib 0.5.0.9000
 
-* Closed (#636): Outputs in sidebars now work as expected when an initially-closed sidebar is opened. (#624)
+## Bug fixes
+
+* Closed #636: Outputs in sidebars now work as expected when an initially-closed sidebar is opened. (#624)
+* Closed #640: `accordion()` no longer errors when an `id` isn't supplied inside a Shiny `session` context. (#646)
 
 # bslib 0.5.0
 

--- a/R/accordion.R
+++ b/R/accordion.R
@@ -56,7 +56,7 @@ accordion <- function(..., id = NULL, open = NULL, multiple = TRUE, class = NULL
   attrs <- args[nzchar(argnames)]
   children <- args[!nzchar(argnames)]
 
-  if (isNamespaceLoaded("shiny")) {
+  if (!is.null(id) && isNamespaceLoaded("shiny")) {
     open <- shiny::restoreInput(id = id, default = open)
   }
 


### PR DESCRIPTION
Closes #640