### PR TITLE
Shiny preset theme review and updates

### DIFF
--- a/inst/builtin/bs5/shiny/_rules.scss
+++ b/inst/builtin/bs5/shiny/_rules.scss
@@ -26,17 +26,8 @@ $web-font-path: "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,
   margin-right: -1px;
 }
 
-// Make all buttons outline buttons by default, but users can add `btn-solid`
-// to use the "normal" solid styles
-@each $color, $value in $theme-colors {
-  .btn-#{$color} {
-    @if $color == "default" {
-      @include button-outline-variant($dark);
-    } @else {
-      @include button-outline-variant($value);
-    }
-  }
-  .btn-#{$color}.btn-solid {
-    @include button-variant($value, $value);
-  }
+// Make the default action button an outline variant, but not others
+.btn-outline-default,
+.btn-default:not(.btn-primary, .btn-secondary, .btn-info, .btn-success, .btn-danger, .btn-warning, .btn-light, .btn-dark, .btn-link, [class*="btn-outline-"]) {
+  @include button-outline-variant($secondary);
 }

--- a/inst/builtin/bs5/shiny/_variables.scss
+++ b/inst/builtin/bs5/shiny/_variables.scss
@@ -17,11 +17,11 @@ $gray-100: #f8f8f8 !default;
 $gray-200: #e9ecef !default;
 $gray-300: #dee2e6 !default;
 $gray-400: #cdd4da !default;
-$gray-500: #8d959e !default;
+$gray-500: #8D959E !default;
 $gray-600: #707782 !default;
-$gray-700: #48505f !default;
-$gray-800: #343a46 !default;
-$gray-900: #1d1f21 !default;
+$gray-700: #48505F !default;
+$gray-800: #343A46 !default;
+$gray-900: #1D1F21 !default;
 
 $default: $gray-300 !default;
 $primary: $blue !default;
@@ -80,7 +80,7 @@ $btn-padding-x: 2em !default;
 $form-check-input-width: 1.2em !default;
 $form-check-input-border-radius: 2px !default;
 $form-check-margin-bottom: 0.25rem !default;
-$form-text-color: $red !default;
+$form-text-color: $gray-600 !default;
 
 // Borders
 $input-border-color: $gray-500 !default;


### PR DESCRIPTION
* Make only the default `actionButton()` the outline variant, keeping `btn-primary` and friends the solid variant.
* Update the gray color values.
* Use `$gray-600` instead of `$red` for `$form-text-color`

![image](https://github.com/rstudio/bslib/assets/5420529/9f10777f-69e0-4217-946c-1100373b46a7)
