### PR TITLE
Update `@types/rstudio-shiny` in `yarn.lock`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -302,7 +302,7 @@
 
 "@types/rstudio-shiny@https://github.com/rstudio/shiny#v1.7.4":
   version "1.7.4"
-  resolved "https://github.com/rstudio/shiny#4d276b307e73b1d312833f03a873e5c16a2dad48"
+  resolved "https://github.com/rstudio/shiny#6176f03ad0a706bfdf265ff23bd5ea7d90802a06"
   dependencies:
     "@types/bootstrap" "3.4.0"
     "@types/bootstrap-datepicker" "0.0.14"


### PR DESCRIPTION
Updates `yarn.lock` to find the correct reference for

```
    "@types/rstudio-shiny": "https://github.com/rstudio/shiny#v1.7.4",
```

The goal is to fix errors seen in CI, e.g. https://github.com/rstudio/bslib/actions/runs/5426683169/jobs/9947977664

FYI, this was a surgical update: I removed `@types/rstudio-shiny` from the lockfile and from `node_modules/` and then ran `yarn install`.