### PR TITLE
Make sure value_box()'s dependency doesn't create an empty card-body (i.e., card item)

### DIFF
--- a/R/value-box.R
+++ b/R/value-box.R
@@ -71,7 +71,7 @@ value_box <- function(title, value, ..., showcase = NULL, showcase_layout = show
     fill = fill,
     !!!attribs,
     contents,
-    component_dependency_css("value_box")
+    as.card_item(component_dependency_css("value_box"))
   )
 
   as_fragment(tag_require(res, version = 5, caller = "value_box()"))


### PR DESCRIPTION
Closes #666. Follow up to #664. 