### PR TITLE
fix(bs_theme_preview): Don't include dashboard tab for BS < 5

### DIFF
--- a/inst/themer-demo/app.R
+++ b/inst/themer-demo/app.R
@@ -65,7 +65,7 @@ progressBar <- div(
 
 # This is here for shinycoreci to take advantage of (so we don't need to update a bunch of screenshots)
 IS_LEGACY <- as.logical(Sys.getenv("BSLIB_LEGACY_THEMER_APP", FALSE))
-if (isTRUE(IS_LEGACY)) {
+if (isTRUE(IS_LEGACY) || theme_version(theme) %in% c("3", "4")) {
   dashboardTab <- NULL
 } else {
   dashboardTab <- nav_panel("Dashboard", tipsUI("tips"))


### PR DESCRIPTION
Currently, if you use `bs_theme_preview()` with BS version < 5, the app fails to load due to `layout_column_wrap()` requiring Bootstrap 5 (that's just the first BS5 requirement).

```r
bs_theme(4) |> bs_theme_preview()
```

![image](https://github.com/rstudio/bslib/assets/5420529/81898764-caae-4db4-a384-70de6f1e2ff1)

This PR adds a version check and only includes the dashboard page if the theme is BS5+.