### PR TITLE
feat(bs_theme_preview): Add more DT features and more tables

### DIFF
--- a/inst/themer-demo/app.R
+++ b/inst/themer-demo/app.R
@@ -72,6 +72,12 @@ if (isTRUE(IS_LEGACY)) {
   theme_set(theme_minimal())
 }
 
+bs_table <- function(x, class = NULL, ...) {
+  class <- paste(c("table", class), collapse = " ")
+  class <- sprintf('class="%s"', class)
+  HTML(knitr::kable(x, format = "html", table.attr = class))
+}
+
 shinyApp(
   page_navbar(
     theme = theme,
@@ -159,7 +165,22 @@ shinyApp(
     ),
     nav_panel(
       "Tables",
-      DT::dataTableOutput("DT")
+      tabsetPanel(
+        id = "tables",
+        tab(
+          "DataTables",
+          DT::dataTableOutput("DT")
+        ),
+        tab(
+          "Bootstrap",
+          h3("Plain tables", class = "mt-2 mb-1"),
+          bs_table(mtcars[1:5, 1:5]),
+          h3("Striped tables", class = "mt-4 mb-1"),
+          bs_table(mtcars[1:5, 1:5], class = "table-striped"),
+          h3("Striped tables with hover", class = "mt-4 mb-1"),
+          bs_table(mtcars[1:5, 1:5], class = "table-striped table-hover")
+        )
+      )
     ),
     nav_panel(
       "Notifications",
@@ -247,7 +268,17 @@ shinyApp(
   function(input, output, session) {
 
     output$DT <- DT::renderDataTable({
-      DT::datatable(mtcars, style = "bootstrap4")
+      cars <- mtcars
+      for (var in c("cyl", "vs", "am", "gear", "carb")) {
+        cars[[var]] <- factor(cars[[var]])
+      }
+
+      DT::datatable(
+        cars,
+        style = "auto",
+        caption = "A generic table made with the DT package and the DataTables library.",
+        filter = "top"
+      )
     })
 
     output$inputPanelOutputHeader <- renderText({


### PR DESCRIPTION
Adds a few more tables and table features to the `bs_theme_preview()` app:

1. I added tabs under the Tables page with DataTables and Bootstrap (tables)
2. The DataTables example updates:
    * Now uses more features – added filters and a caption. Filters use factors and numeric values.
    * Uses `style="auto"` rather than defaulting to `"bootstrap4"` 
    * See rstudio/DT#1074 for improved auto style support
3. The Bootstrap tabs include plain tables, striped tables and tables with hover accents.