### PR TITLE
ci(lock-threads): Automatically lock closed, inactive issues

### DIFF
--- a/.github/workflows/lock-threads.yaml
+++ b/.github/workflows/lock-threads.yaml
@@ -1,0 +1,38 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '42 5 * * *' # 5:42 AM UTC every day
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  # Enable the line below if you turn on pull request locking
+  # pull-requests: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4
+        with:
+          # Remove the line below to turn on pull request locking
+          process-only: 'issues'
+
+          # Issue-locking options
+          issue-inactive-days: 60
+          issue-comment: >
+            This issue has been automatically locked. If you believe you have
+            found a related problem, please open a new issue (with
+            [a reprex](https://reprex.tidyverse.org/)) and link to this issue.
+
+          # Pull request-locking options
+          pr-inactive-days: 60
+          pull-comment: >
+            This pull request has been automatically locked. If you believe
+            you have found a related problem, please open a new issue
+            (with [a reprex](https://reprex.tidyverse.org/)) and link to this
+            pull request.

--- a/.github/workflows/lock-threads.yaml
+++ b/.github/workflows/lock-threads.yaml
@@ -1,8 +1,9 @@
-name: 'Lock Threads'
+name: 'Lock Closed Threads'
 
 on:
   schedule:
-    - cron: '42 5 * * *' # 5:42 AM UTC every day
+    - cron: '42 5 * * 1' # 5:42 AM UTC every Monday
+  repository_dispatch: { types: [lock_threads] }
   workflow_dispatch:
 
 permissions:
@@ -14,25 +15,5 @@ concurrency:
   group: lock-threads
 
 jobs:
-  action:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: dessant/lock-threads@v4
-        with:
-          # Remove the line below to turn on pull request locking
-          process-only: 'issues'
-
-          # Issue-locking options
-          issue-inactive-days: 60
-          issue-comment: >
-            This issue has been automatically locked. If you believe you have
-            found a related problem, please open a new issue (with
-            [a reprex](https://reprex.tidyverse.org/)) and link to this issue.
-
-          # Pull request-locking options
-          pr-inactive-days: 60
-          pull-comment: >
-            This pull request has been automatically locked. If you believe
-            you have found a related problem, please open a new issue
-            (with [a reprex](https://reprex.tidyverse.org/)) and link to this
-            pull request.
+  lock-threads:
+    uses: rstudio/shiny-workflows/.github/workflows/lock-threads.yaml@v1


### PR DESCRIPTION
Adds rstudio/shiny-workflows#20 to lock closed issues that haven't had activity in the last 60 days. This workflow would run once per week (early Monday morning) to lock inactive issues (or manually with a workflow dispatch).

There are [currently 216 such issues in bslib](https://github.com/search?q=repo:rstudio/bslib+is:closed+is:unlocked+updated:%3C2023-04-15&type=issues) that would be locked. The action will handle 50 at a time to avoid rate-limiting issues.