### PR TITLE
fix(bootswatch): Exclude `.btn-light` from `.btn-default` extension of `.btn-secondary`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Closed #636: Outputs in sidebars now work as expected when an initially-closed sidebar is opened. (#624)
 * Closed #640: `accordion()` no longer errors when an `id` isn't supplied inside a Shiny `session` context. (#646)
 * Closed #639: `nav_panel()`'s `icon` argument now supports generic `HTML()`, meaning that things like `bsicons::bs_icon()` and `fontawesome::fa()` can be used as values. (#645)
+* Light-styled buttons in bslib-provided Bootswatch themes are now consistent with their design in Bootswatch. Previously, they were inadvertently styled similarly to secondary buttons. (#687)
 
 # bslib 0.5.0
 

--- a/R/bs-theme-preset-bootswatch.R
+++ b/R/bs-theme-preset-bootswatch.R
@@ -106,7 +106,7 @@ bootswatch_bundle <- function(bootswatch, version) {
         if (identical(bootswatch, "sketchy")) ".dropdown-menu{ overflow: inherit; }" else "",
         # Several Bootswatch themes (e.g., zephyr, simplex, etc) add custom .btn-secondary
         # rules that should also apply to .btn-default
-        ".btn-default:not(.btn-primary):not(.btn-info):not(.btn-success):not(.btn-warning):not(.btn-danger):not(.btn-dark):not(.btn-outline-primary):not(.btn-outline-info):not(.btn-outline-success):not(.btn-outline-warning):not(.btn-outline-danger):not(.btn-outline-dark) {
+        ".btn-default:not(.btn-primary):not(.btn-info):not(.btn-success):not(.btn-warning):not(.btn-danger):not(.btn-dark):not(.btn-light):not(.btn-outline-primary):not(.btn-outline-info):not(.btn-outline-success):not(.btn-outline-warning):not(.btn-outline-danger):not(.btn-outline-dark) {
           @extend .btn-secondary !optional;
         }"
       )

--- a/R/bs-theme-preset-bootswatch.R
+++ b/R/bs-theme-preset-bootswatch.R
@@ -106,7 +106,7 @@ bootswatch_bundle <- function(bootswatch, version) {
         if (identical(bootswatch, "sketchy")) ".dropdown-menu{ overflow: inherit; }" else "",
         # Several Bootswatch themes (e.g., zephyr, simplex, etc) add custom .btn-secondary
         # rules that should also apply to .btn-default
-        ".btn-default:not(.btn-primary):not(.btn-info):not(.btn-success):not(.btn-warning):not(.btn-danger):not(.btn-dark):not(.btn-light):not(.btn-outline-primary):not(.btn-outline-info):not(.btn-outline-success):not(.btn-outline-warning):not(.btn-outline-danger):not(.btn-outline-dark) {
+        ".btn-default:not(.btn-primary):not(.btn-info):not(.btn-success):not(.btn-warning):not(.btn-danger):not(.btn-dark):not(.btn-light):not([class*='btn-outline-']) {,
           @extend .btn-secondary !optional;
         }"
       )

--- a/R/bs-theme-preset-bootswatch.R
+++ b/R/bs-theme-preset-bootswatch.R
@@ -106,7 +106,7 @@ bootswatch_bundle <- function(bootswatch, version) {
         if (identical(bootswatch, "sketchy")) ".dropdown-menu{ overflow: inherit; }" else "",
         # Several Bootswatch themes (e.g., zephyr, simplex, etc) add custom .btn-secondary
         # rules that should also apply to .btn-default
-        ".btn-default:not(.btn-primary):not(.btn-info):not(.btn-success):not(.btn-warning):not(.btn-danger):not(.btn-dark):not(.btn-light):not([class*='btn-outline-']) {,
+        ".btn-default:not(.btn-primary):not(.btn-info):not(.btn-success):not(.btn-warning):not(.btn-danger):not(.btn-dark):not(.btn-light):not([class*='btn-outline-']) {
           @extend .btn-secondary !optional;
         }"
       )


### PR DESCRIPTION
While looking into #684, I noticed that we have some style spillover between `.btn-default` and `.btn-light`. We were essentially causing some of the `.btn-secondary` styles that we're extending to `.btn-default` to be applied to `.btn-light` as well.