### PR TITLE
fix(shiny-preset): Adjust slider handle size and position to better center on line and bar

### DIFF
--- a/inst/builtin/bs5/shiny/ionrangeslider/_rules.scss
+++ b/inst/builtin/bs5/shiny/ionrangeslider/_rules.scss
@@ -13,7 +13,7 @@
   }
 
   .irs-handle {
-    top: $handle_radius + 1px;
+    top: $top - ($handle_height / 2) + ($line_height / 2);
   }
 
   .irs-bar {

--- a/inst/builtin/bs5/shiny/ionrangeslider/_rules.scss
+++ b/inst/builtin/bs5/shiny/ionrangeslider/_rules.scss
@@ -13,7 +13,7 @@
   }
 
   .irs-handle {
-    top: $handle_radius;
+    top: $handle_radius + 1px;
   }
 
   .irs-bar {

--- a/inst/builtin/bs5/shiny/ionrangeslider/_variables.scss
+++ b/inst/builtin/bs5/shiny/ionrangeslider/_variables.scss
@@ -14,7 +14,7 @@ $handle_color_hover: tint-color($handle_color, 15%) !default;
 $handle_border: none !default;
 $handle_box_shadow: none !default;
 $handle_radius: $top - 10px !default;
-$handle_height: 19px !default;
+$handle_height: 18px !default;
 $handle_width: $handle_height !default;
 
 $bar_color: $component-active-bg !default;

--- a/inst/builtin/bs5/shiny/ionrangeslider/_variables.scss
+++ b/inst/builtin/bs5/shiny/ionrangeslider/_variables.scss
@@ -14,7 +14,7 @@ $handle_color_hover: tint-color($handle_color, 15%) !default;
 $handle_border: none !default;
 $handle_box_shadow: none !default;
 $handle_radius: $top - 10px !default;
-$handle_height: 18px !default;
+$handle_height: 19px !default;
 $handle_width: $handle_height !default;
 
 $bar_color: $component-active-bg !default;


### PR DESCRIPTION
Fixes #691

## Before

![image](https://github.com/rstudio/bslib/assets/5420529/94236a71-58d7-40e9-bc57-c81155136810)

<img src="https://github.com/rstudio/bslib/assets/5420529/1cdecbb5-0310-40b7-8583-076aca1f8ae7" height="200">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://github.com/rstudio/bslib/assets/5420529/c97c2b01-28b5-4ac8-a084-f8842b0d17f9" height="200">


## After

![image](https://github.com/rstudio/bslib/assets/5420529/63e7690f-806b-433c-a803-87f9dabc17db)

<img src="https://github.com/rstudio/bslib/assets/5420529/17beeeef-c0ff-48f8-bd08-3fec7a63faae" alt="image" height="200">
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://github.com/rstudio/bslib/assets/5420529/a911068f-351c-4ebe-8e48-815144ad55e1" alt="image" height="200">
