### PR TITLE
ci(examples): Fix shinyapps.io deployment

### DIFF
--- a/inst/examples/card/deploy.R
+++ b/inst/examples/card/deploy.R
@@ -1,4 +1,6 @@
 rsconnect::deployApp(
   rprojroot::find_package_root_file("inst/examples/card"),
-  appName = "card", account = "testing-apps"
+  appName = "card",
+  account = "testing-apps",
+  forceUpdate = TRUE
 )

--- a/inst/examples/flights/deploy.R
+++ b/inst/examples/flights/deploy.R
@@ -1,4 +1,6 @@
 rsconnect::deployApp(
   rprojroot::find_package_root_file("inst/examples/flights"),
-  appName = "flights", account = "testing-apps"
+  appName = "flights",
+  account = "testing-apps",
+  forceUpdate = TRUE
 )

--- a/inst/examples/value_box/deploy.R
+++ b/inst/examples/value_box/deploy.R
@@ -1,4 +1,6 @@
 rsconnect::deployApp(
   rprojroot::find_package_root_file("inst/examples/value_box"),
-  appName = "value_box", account = "testing-apps"
+  appName = "value_box",
+  account = "testing-apps",
+  forceUpdate = TRUE
 )

--- a/inst/themer-demo/deploy.R
+++ b/inst/themer-demo/deploy.R
@@ -1,4 +1,6 @@
 rsconnect::deployApp(
   rprojroot::find_package_root_file("inst/themer-demo/deploy"),
-  appName = "themer-demo", account = "testing-apps"
+  appName = "themer-demo",
+  account = "testing-apps",
+  forceUpdate = TRUE
 )


### PR DESCRIPTION
This is a bit of a guess, but we might need to include `forceUpdate = TRUE` to signal that we're expecting these apps to already exist. It's possible that this previously worked non-interactively and/or was changed with recent updates in the rsconnect package.

(Although the workflow seems to [be failing intermittently](https://github.com/rstudio/bslib/actions/workflows/R-CMD-check.yaml?query=branch:main+is:success))

 The [typical error we see](https://github.com/rstudio/bslib/actions/runs/5669160858/job/15361771692) in our shinyapps deployment failures is this error:

```
✔ Deploying "themer-demo" to "server: shinyapps.io / username: ***"
ℹ Creating application on server...
Error in `POST()`:
! <https://api.shinyapps.io/v1/applications/> failed with HTTP status 409
Application exists with name: themer-demo
```