### PR TITLE
Another attempt at fixing deploys

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install bslib from GitHub
         shell: Rscript {0}
         run: |
-          install.packages("rsconnect")
+          pak::pkg_install("rstudio/rsconnect")
           pak::pkg_install("rstudio/bslib", dependencies = TRUE, upgrade = TRUE)
 
       # Workaround for this (probably spurious error):

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: Install bslib from GitHub
         shell: Rscript {0}
         run: |
+          # Install dev version to obtain a fix for this issue 
+          # https://github.com/rstudio/rsconnect/issues/926
+          # Once it's on CRAN, we can go back to the CRAN release
           pak::pkg_install("rstudio/rsconnect")
           pak::pkg_install("rstudio/bslib", dependencies = TRUE, upgrade = TRUE)
 


### PR DESCRIPTION
Looks like we're running into this issue https://community.rstudio.com/t/unable-to-deploy-on-shinyapp-io/170160

Instead of downgrading `{rsconnect}`, this'll upgrade to the dev version.