### PR TITLE
feat(shiny-preset): Restore "showing X of Y entries" in small datatables

### DIFF
--- a/inst/builtin/bs5/shiny/tables/_rules.scss
+++ b/inst/builtin/bs5/shiny/tables/_rules.scss
@@ -89,7 +89,7 @@ th {
     // hide the supporting elements when inside a non-full-screen card
     .dataTables_length,  // show ___ entries
     .dataTables_filter,  // search
-    .dataTables_info,    // showing 1 to 10 of 100 entries
+    // .dataTables_info,    // showing 1 to 10 of 100 entries
     .dataTables_paginate {
       display: none;
     }


### PR DESCRIPTION
Fixes #718

![image](https://github.com/rstudio/bslib/assets/5420529/92af8f18-548e-4440-8edf-9103e2def89c)
