### PR TITLE
fix(layout_columns): Use `minmax(0, 1fr)` for column widths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * Closed #640: `accordion()` no longer errors when an `id` isn't supplied inside a Shiny `session` context. (#646)
 * Closed #639: `nav_panel()`'s `icon` argument now supports generic `HTML()`, meaning that things like `bsicons::bs_icon()` and `fontawesome::fa()` can be used as values. (#645)
 * Light-styled buttons in bslib-provided Bootswatch themes are now consistent with their design in Bootswatch. Previously, they were inadvertently styled similarly to secondary buttons. (#687)
+* Closed #727: `layout_column_wrap()` now enforces equal column widths by avoiding layout issues caused by grid container overflow. (#729)
 
 # bslib 0.5.0
 

--- a/R/layout.R
+++ b/R/layout.R
@@ -69,7 +69,7 @@ layout_column_wrap <- function(
       if (num_cols != as.integer(num_cols)) {
         stop("Could not interpret width argument; see ?layout_column_wrap")
       }
-      paste0(rep_len("1fr", num_cols), collapse = " ")
+      sprintf("repeat(%s, minmax(0, 1fr))", num_cols)
     } else {
       if (fixed_width) {
         paste0("repeat(auto-fit, ", validateCssUnit(width), ")")


### PR DESCRIPTION
Fixes #727 

Background in this CSS tricks article: [Preventing a Grid Blowout](https://css-tricks.com/preventing-a-grid-blowout/)

Using `minmax(0, 1fr)` constrains each column to use up to `1fr`, otherwise the intrinsic width of one column can affect the sizes of other columns. (See the example in https://github.com/rstudio/bslib/issues/727#issuecomment-1666172356)


https://github.com/rstudio/bslib/assets/5420529/1408866f-2166-4680-b5b5-d7c1c829e9c3
