### PR TITLE
feat(bs_theme_preview): Add dark mode preview toggle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * Upgraded the default version of Bootstrap from v5.2.2 to v5.3.1. The most notable thing that comes with the update is the ability to toggle between light/dark [color modes](https://getbootstrap.com/docs/5.3/customize/color-modes/) purely client-side (i.e., no calls to Sass required). (#749, #764)
 
+## Improvements
+
+* The `bs_themer()` app now supports previewing the dark mode variant of Bootstrap 5 themes. (#767)
+
 # bslib 0.5.1
 
 ## New features

--- a/inst/themer/options.json
+++ b/inst/themer/options.json
@@ -6,6 +6,11 @@
       // The inlined svg below is the info-circle Bootstrap icon https://icons.getbootstrap.com
       "desc": "<svg width='1em' height='1.25em' viewBox='0 2 16 16' class='bi bi-info-circle' fill='currentColor' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' d='M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z'/><path d='M8.93 6.588l-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588z'/><circle cx='8' cy='4.5' r='1'/></svg> Changing the theme preset may undo other theming changes."
     },
+    "dark-mode": {
+      "type": "switch",
+      "label": "Preview dark mode <a href=\"#\" data-bs-toggle=\"tooltip\" data-bs-title=\"New in Bootstrap 5.3! Automatically adapts a light theme for dark mode.\"><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" fill=\"currentColor\" class=\"bi bi-info-circle\" viewBox=\"0 0 16 16\"><path d=\"M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z\"/><path d=\"m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z\"/></svg></i></a>",
+      "version": {"min": 5}
+    },
     "bg": {
       "type": "color",
       "label": "Background (bg) color"

--- a/inst/themer/options.json
+++ b/inst/themer/options.json
@@ -8,7 +8,7 @@
     },
     "dark-mode": {
       "type": "switch",
-      "label": "Preview dark mode <a href=\"#\" data-bs-toggle=\"tooltip\" data-bs-title=\"New in Bootstrap 5.3! Automatically adapts a light theme for dark mode.\"><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" fill=\"currentColor\" class=\"bi bi-info-circle\" viewBox=\"0 0 16 16\"><path d=\"M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z\"/><path d=\"m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z\"/></svg></i></a>",
+      "label": "Preview dark mode <a href=\"#\" data-bs-toggle=\"tooltip\" data-bs-title=\"New in Bootstrap 5.3! Automatically adapts a light theme for dark mode.\"><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" fill=\"currentColor\" class=\"bi bi-info-circle\" style="vertical-align:-0.125em;" viewBox=\"0 0 16 16\"><path d=\"M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z\"/><path d=\"m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z\"/></svg></i></a>",
       "version": {"min": 5}
     },
     "bg": {

--- a/inst/themer/themer.js
+++ b/inst/themer/themer.js
@@ -227,6 +227,11 @@
     }
   });
 
+  $(document).on("change", "#bsthemer-dark-mode", function(ev) {
+    document.body.dataset.bsTheme = ev.target.checked ? "dark" : "light";
+    $(window).resize();
+  });
+
   function initSelectInput(el) {
   }
 
@@ -297,6 +302,13 @@
     }
     syncing = false;
   })
+
+  // Initialize tooltips in the themer container
+  $(document).ready(function() {
+    document
+      .querySelectorAll('#bsthemerContainer [data-bs-toggle="tooltip"]')
+      .forEach((tooltipNode) => new window.bootstrap.Tooltip(tooltipNode));
+  });
 
   /*** Begin dragging logic ***/
 


### PR DESCRIPTION
Adds a "Preview dark mode" toggle to the theme previewer. This only toggles the dark mode on the page – in the future we may want to add more support for updating dark mode colors, but that isn't part of this PR. 

I added a tooltip with info about the dark mode feature, where I tried to word the tip text to indicate that the colors in the customization menu are still for light mode.

![image](https://github.com/rstudio/bslib/assets/5420529/c83c4627-8d67-4e31-aa22-daa531bd74ce)

## Preview

https://github.com/rstudio/bslib/assets/5420529/de1a52fe-a3f4-4f0e-9f17-aeb3c9142f30

## Notes

- I added a new `switch` input control type to the themer controls.

- The `options.json` can now communicate minimum Bootstrap versions for input controls. The dark mode switch gets `"version": {"min": 5}`.

- Thought for the future: the `options.json` might be able to encode more things, like which inputs directly correspond to Sass variables. If you add a new input that isn't supposed to be passed down to Sass, you have to exclude it in the app logic or it will crash the app. For now, I just added `dark-mode` the exclusion list.