### PR TITLE
docs(pkgdown): Fix pkgdown links in dark mode

### DIFF
--- a/pkgdown/extra.scss
+++ b/pkgdown/extra.scss
@@ -170,6 +170,13 @@ footer {
   background-color: rgba(var(--bs-info-rgb), 0.75);
 }
 
+@include media-breakpoint-down(sm) {
+  aside {
+    background-color: var(--bs-tertiary-bg);
+    border-color: var(--bs-border-color);
+  }
+}
+
 /* ---- Dark Mode ---- */
 [data-bs-theme="dark"] {
   .navbar.bg-info {


### PR DESCRIPTION
Fixes the background color of the links panel in dark mode on mobile screens. (pkgdown has some custom styles that don't adapt to the color mode change.)