### PR TITLE
docs: Use `@section` for navset examples

### DIFF
--- a/R/navs-legacy.R
+++ b/R/navs-legacy.R
@@ -2,7 +2,10 @@
 #'
 #' Render a collection of [nav_panel()] items into a container.
 #'
-#' @includeRmd man/fragments/ex-navset_tab.Rmd
+#' @section Examples:
+#'
+#' ```{r child="man/fragments/ex-navset_tab.Rmd"}
+#' ```
 #'
 #' @param ... a collection of [nav_panel()] items.
 #' @param id a character string used for dynamically updating the container (see

--- a/man/fragments/ex-navset_tab.Rmd
+++ b/man/fragments/ex-navset_tab.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 ```{r child="0-screenshot-examples.Rmd"}
 ```
 
-## A basic example
+### A basic example
 
 This first example creates a simple tabbed navigation container with two tabs.
 The tab name and the content of each tab are specified in the `nav_panel()` calls
@@ -36,7 +36,7 @@ link_shiny <- tags$a(shiny::icon("github"), "Shiny", href = "https://github.com/
 link_posit <- tags$a(shiny::icon("r-project"), "Posit", href = "https://posit.co", target = "_blank")
 ```
 
-## `navset_tab()`
+### `navset_tab()`
 
 You can fully customize the controls in the navigation component.
 In this example, we've added a direct link to the Shiny repository using `nav_item()`.
@@ -62,7 +62,7 @@ navset_tab(
 )
 ```
 
-## `navset_pill()`
+### `navset_pill()`
 
 `navset_pill()` creates a navigation container that behaves exactly like `navset_tab()`,
 but the tab toggles are _pills_ or button-shaped.
@@ -82,7 +82,7 @@ navset_pill(
 )
 ```
 
-## `navset_card_tab()`
+### `navset_card_tab()`
 
 The tabbed navigation container can also be used in a `card()` component
 thanks to `navset_card_tab()`.
@@ -107,7 +107,7 @@ navset_card_tab(
 )
 ```
 
-## `navset_card_pill()`
+### `navset_card_pill()`
 
 Similar to `navset_pill()`,
 `navset_card_pill()` provides a pill-shaped variant to `navset_card_tab()`.
@@ -130,7 +130,7 @@ navset_card_pill(
 )
 ```
 
-## `navset_pill_list()`
+### `navset_pill_list()`
 
 Furthermore, `navset_pill_list()` creates a vertical list of navigation controls
 adjacent to, rather than on top of, the tab content panels.
@@ -150,7 +150,7 @@ navset_pill_list(
 )
 ```
 
-## `page_navbar()`
+### `page_navbar()`
 
 Finally, `page_navbar()` provides full-page navigation container
 similar to `navset_tab()` but where each `nav_panel()` is treated as a full page of content

--- a/man/navset.Rd
+++ b/man/navset.Rd
@@ -153,13 +153,13 @@ together into one \code{wrapper} call (e.g. given \code{card("a", "b", card_body
 \description{
 Render a collection of \code{\link[=nav_panel]{nav_panel()}} items into a container.
 }
-\details{
+\section{Examples}{
+
 \subsection{A basic example}{
 
-This first example creates a simple tabbed navigation container with two
-tabs. The tab name and the content of each tab are specified in the
-\code{nav_panel()} calls and \code{navset_tab()} creates the tabbed navigation
-around these two tabs.
+This first example creates a simple tabbed navigation container with two tabs.
+The tab name and the content of each tab are specified in the \code{nav_panel()} calls
+and \code{navset_tab()} creates the tabbed navigation around these two tabs.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{library(htmltools)
 
@@ -171,8 +171,7 @@ navset_tab(
 
 \figure{navset-tab-basic.png}{Screenshot of a basic navset_tab() example.}
 
-In the rest of the examples, we’ll include links among the tabs (or
-pills) in the navigation controls.
+In the rest of the examples, we'll include links among the tabs (or pills) in the navigation controls.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{link_shiny <- tags$a(shiny::icon("github"), "Shiny", href = "https://github.com/rstudio/shiny", target = "_blank")
 link_posit <- tags$a(shiny::icon("r-project"), "Posit", href = "https://posit.co", target = "_blank")
@@ -181,13 +180,14 @@ link_posit <- tags$a(shiny::icon("r-project"), "Posit", href = "https://posit.co
 
 \subsection{\code{navset_tab()}}{
 
-You can fully customize the controls in the navigation component. In
-this example, we’ve added a direct link to the Shiny repository using
-\code{nav_item()}. We’ve also included a dropdown menu using \code{nav_menu()}
-containing an option to select a third tab panel and another direct link
-to Posit’s website. Finally, we’ve separated the primary tabs on the
-left from the direct link and dropdown menu on the right using
-\code{nav_spacer()}.
+You can fully customize the controls in the navigation component.
+In this example, we've added a direct link to the Shiny repository using \code{nav_item()}.
+We've also included a dropdown menu using \code{nav_menu()}
+containing an option to select a third tab panel
+and another direct link to Posit's website.
+Finally, we've separated the primary tabs on the left
+from the direct link and dropdown menu on the right
+using \code{nav_spacer()}.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{navset_tab(
   nav_panel(title = "One", p("First tab content.")),
@@ -208,8 +208,8 @@ left from the direct link and dropdown menu on the right using
 
 \subsection{\code{navset_pill()}}{
 
-\code{navset_pill()} creates a navigation container that behaves exactly like
-\code{navset_tab()}, but the tab toggles are \emph{pills} or button-shaped.
+\code{navset_pill()} creates a navigation container that behaves exactly like \code{navset_tab()},
+but the tab toggles are \emph{pills} or button-shaped.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{navset_pill(
   nav_panel(title = "One", p("First tab content.")),
@@ -231,11 +231,12 @@ left from the direct link and dropdown menu on the right using
 \subsection{\code{navset_card_tab()}}{
 
 The tabbed navigation container can also be used in a \code{card()} component
-thanks to \code{navset_card_tab()}. Learn more about this approach in the
-\href{https://pkgs.rstudio.com/bslib/articles/cards.html}{article about Cards}, including
-how to add \href{https://pkgs.rstudio.com/bslib/articles/sidebars.html#multi-page-layout}{a shared sidebar}
-to all tabs in the card using the \code{sidebar} argument of
-\code{navset_card_tab()}.
+thanks to \code{navset_card_tab()}.
+Learn more about this approach in the
+\href{https://pkgs.rstudio.com/bslib/articles/cards.html}{article about Cards},
+including how to add \href{https://pkgs.rstudio.com/bslib/articles/sidebars.html#multi-page-layout}{a shared sidebar}
+to all tabs in the card
+using the \code{sidebar} argument of \code{navset_card_tab()}.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{navset_card_tab(
   nav_panel(title = "One", p("First tab content.")),
@@ -256,9 +257,10 @@ to all tabs in the card using the \code{sidebar} argument of
 
 \subsection{\code{navset_card_pill()}}{
 
-Similar to \code{navset_pill()}, \code{navset_card_pill()} provides a pill-shaped
-variant to \code{navset_card_tab()}. You can use the \code{placement} argument to
-position the navbar \code{"above"} or \code{"below"} the card body.
+Similar to \code{navset_pill()},
+\code{navset_card_pill()} provides a pill-shaped variant to \code{navset_card_tab()}.
+You can use the \code{placement} argument to position the navbar
+\code{"above"} or \code{"below"} the card body.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{navset_card_pill(
   placement = "above",
@@ -280,8 +282,8 @@ position the navbar \code{"above"} or \code{"below"} the card body.
 
 \subsection{\code{navset_pill_list()}}{
 
-Furthermore, \code{navset_pill_list()} creates a vertical list of navigation
-controls adjacent to, rather than on top of, the tab content panels.
+Furthermore, \code{navset_pill_list()} creates a vertical list of navigation controls
+adjacent to, rather than on top of, the tab content panels.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{navset_pill_list(
   nav_panel(title = "One", p("First tab content.")),
@@ -302,10 +304,9 @@ controls adjacent to, rather than on top of, the tab content panels.
 
 \subsection{\code{page_navbar()}}{
 
-Finally, \code{page_navbar()} provides full-page navigation container similar
-to \code{navset_tab()} but where each \code{nav_panel()} is treated as a full page
-of content and the navigation controls appear in a top-level navigation
-bar.
+Finally, \code{page_navbar()} provides full-page navigation container
+similar to \code{navset_tab()} but where each \code{nav_panel()} is treated as a full page of content
+and the navigation controls appear in a top-level navigation bar.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{page_navbar(
   title = "My App",
@@ -326,6 +327,7 @@ bar.
 \figure{page-navbar.png}{Screenshot of a page_navbar() example.}
 }
 }
+
 \seealso{
 \code{\link[=nav_panel]{nav_panel()}}, \code{\link[=nav_select]{nav_select()}}.
 }


### PR DESCRIPTION
Fixes #777

Moves the examples and screenshots into an Examples section