### PR TITLE
Feat(value-box): Tweaks for dark mode

### DIFF
--- a/inst/builtin/bs5/shiny/_rules.scss
+++ b/inst/builtin/bs5/shiny/_rules.scss
@@ -91,18 +91,29 @@ $icon-classes: ("bi", "fa", "fas", "far", "fab", "material-icons") !default;
   }
 }
 
+
 .bslib-value-box {
-  &.text-info,
-  &.text-cyan {
-    --bslib-color-fg: #028097 !important; // Contrast 4.63
+  $cyan: #028097; // Contrast 4.63
+  $warning: #A87600; // Contrast 4 (okay for 16px+ text)
+
+  &.text-info {
+    &, &.text-cyan {
+      --bslib-color-fg: $cyan !important;
+    }
+    color: $cyan !important;
   }
+
   &.text-light {
     --bslib-color-fg: $gray-600 !important;
   }
-  &.text-yellow.text-yellow,
-  &.text-warning.text-warning {
-    --bslib-color-fg: #A87600; // Contrast 4 (okay for 16px+ text)
+
+  &.text-warning {
+    &, &.text-yellow {
+      --bslib-color-fg: $warning !important;
+    }
+    color: $warning !important;
   }
+
   &.text-teal.text-teal {
     --bslib-color-fg: #008558; // Contrast 4.67
   }

--- a/inst/builtin/bs5/shiny/_rules.scss
+++ b/inst/builtin/bs5/shiny/_rules.scss
@@ -94,16 +94,16 @@ $icon-classes: ("bi", "fa", "fas", "far", "fab", "material-icons") !default;
 .bslib-value-box {
   &.text-info,
   &.text-cyan {
-    color: #028097 !important; // Contrast 4.63
+    --bslib-color-fg: #028097 !important; // Contrast 4.63
   }
   &.text-light {
-    color: $gray-600 !important;
+    --bslib-color-fg: $gray-600 !important;
   }
   &.text-yellow.text-yellow,
   &.text-warning.text-warning {
-    color: #A87600; // Contrast 4 (okay for 16px+ text)
+    --bslib-color-fg: #A87600; // Contrast 4 (okay for 16px+ text)
   }
   &.text-teal.text-teal {
-    color: #008558; // Contrast 4.67
+    --bslib-color-fg: #008558; // Contrast 4.67
   }
 }

--- a/inst/components/scss/value_box.scss
+++ b/inst/components/scss/value_box.scss
@@ -233,3 +233,10 @@ $bslib-value-box-horizontal-break-point: 300px;
     }
   }
 }
+
+@include color-mode(dark) {
+  .bslib-value-box {
+    // Bootstrap doesn't have a dark shadow, but the default isn't quite right
+    --bslib-value-box-shadow: 0 0.5rem 1rem rgb(0 0 0 / 50%);
+  }
+}


### PR DESCRIPTION
* Use a darker shadow for values boxes (if enabled) in dark mode
* Updates the shiny preset color adjustments for value box foreground colors to use the new `--bslib-color-fg` custom props