### PR TITLE
Fix use of rlang::is_string() inside of toggle_switch()

### DIFF
--- a/R/input-switch.R
+++ b/R/input-switch.R
@@ -64,7 +64,7 @@ toggle_switch <- function(id, value = NULL, session = get_current_session()) {
     abort("`value` must be a `NULL` or a single logical value.")
   }
 
-  if (!rlang::is_string(id, n = 1)) {
+  if (!rlang::is_string(id)) {
     abort("`id` must be a single string containing the `id` of a switch input.")
   }
 


### PR DESCRIPTION
Introduced by https://github.com/rstudio/bslib/pull/709. Fixes the following error (discovered through and will fix https://rstudio.github.io/shinycoreci/results/2023/09/11/#315-bslib-input-switch)

```r
library(shiny)
library(bslib)

ui <- page_fixed(
  input_switch("x", "Switch")
)

server <- function(input, output, session) {
  toggle_switch("x")
}

shinyApp(ui, server)
```

```r
Error in rlang::is_string(id, n = 1) : unused argument (n = 1)
```