### PR TITLE
fix(preset): Fix typo in error message

### DIFF
--- a/R/bs-theme-preset.R
+++ b/R/bs-theme-preset.R
@@ -98,7 +98,7 @@ assert_preset_only_one_name_arg <- function(preset, bootswatch, .frame = rlang::
   }
 
   msg <- c(
-    "Only one of `preset` or `bootswatch` may be provided, and `name` is preferred.",
+    "Only one of `preset` or `bootswatch` may be provided (`preset` is the preferred choice).",
     "i" = "Did you mean one of the following options?",
     "*" = sprintf('`preset = "%s"`', preset),
     "*" = sprintf('`preset = "%s"`', bootswatch),

--- a/tests/testthat/_snaps/bs-theme-preset.md
+++ b/tests/testthat/_snaps/bs-theme-preset.md
@@ -3,7 +3,7 @@
     Code
       resolve_bs_preset(preset = "name", bootswatch = "bootswatch")
     Error <rlang_error>
-      Only one of `preset` or `bootswatch` may be provided, and `name` is preferred.
+      Only one of `preset` or `bootswatch` may be provided (`preset` is the preferred choice).
       i Did you mean one of the following options?
       * `preset = "name"`
       * `preset = "bootswatch"`


### PR DESCRIPTION
Fixes a small typo in the error message when both `preset` and `bootswatch` are provided. (Example in snapshot diff.)