### PR TITLE
docs(tooltip,popover): Document trigger accessibility considerations

### DIFF
--- a/R/popover.R
+++ b/R/popover.R
@@ -26,12 +26,8 @@
 #'
 #' @section Theming/Styling:
 #'
-#'   Like other bslib components, popovers can be themed by supplying [relevant
-#'   theming
-#'   variables](https://rstudio.github.io/bslib/articles/bs5-variables/index.html#popover-bg)
-#'   to [bs_theme()], which effects styling of every popover on the page. To
-#'   style a _specific_ popover differently from other popovers, utilize the
-#'   `customClass` option:
+#'   ```{r child="man/fragments/tooltip-popover_theming.Rmd", el = "popover"}
+#'   ```
 #'
 #'   ```
 #'   popover(
@@ -44,6 +40,19 @@
 #'
 #'   ```
 #'   bs_theme() |> bs_add_rules(".my-pop { max-width: none; }")
+#'   ```
+#'
+#' @section Accessibility of Popover Triggers:
+#'
+#'   ```{r child="man/fragments/tooltip-popover_a11y-trigger.Rmd", el = "popover"}
+#'   ```
+#'
+#'   ```r
+#'   popover(
+#'     bsicons::bs_icon("gear", title = "Settings"),
+#'     title = "Settings",
+#'     sliderInput("n", "Number of points", 1, 100, 50)
+#'   )
 #'   ```
 #'
 #' @describeIn popover Add a popover to a UI element

--- a/R/popover.R
+++ b/R/popover.R
@@ -55,6 +55,14 @@
 #'   )
 #'   ```
 #'
+#'   ```r
+#'   popover(
+#'     fontawesome::fa("gear", a11y = "sem", title = "Settings"),
+#'     title = "Settings",
+#'     sliderInput("n", "Number of points", 1, 100, 50)
+#'   )
+#'   ```
+#'
 #' @describeIn popover Add a popover to a UI element
 #' @references <https://getbootstrap.com/docs/5.3/components/popovers/>
 #' @export

--- a/R/tooltip.R
+++ b/R/tooltip.R
@@ -40,7 +40,14 @@
 #'
 #'   ```r
 #'   tooltip(
-#'     bsicons::bs_icon("info-circle", title = "About tooltips."),
+#'     bsicons::bs_icon("info-circle", title = "About tooltips"),
+#'     "Text shown in the tooltip."
+#'   )
+#'   ```
+#'
+#'   ```r
+#'   tooltip(
+#'     fontawesome::fa("info-circle", title = "About tooltips"),
 #'     "Text shown in the tooltip."
 #'   )
 #'   ```

--- a/R/tooltip.R
+++ b/R/tooltip.R
@@ -17,12 +17,8 @@
 #'
 #' @section Theming/Styling:
 #'
-#'   Like other bslib components, tooltips can be themed by supplying [relevant
-#'   theming
-#'   variables](https://rstudio.github.io/bslib/articles/bs5-variables/index.html#tooltip-bg)
-#'   to [bs_theme()], which effects styling of every popover on the page. To
-#'   style a _specific_ popover differently from other popovers, utilize the
-#'   `customClass` option:
+#'   ```{r child="man/fragments/tooltip-popover_theming.Rmd", el="tooltip"}
+#'   ```
 #'
 #'   ```
 #'   tooltip(
@@ -35,6 +31,18 @@
 #'
 #'   ```
 #'   bs_theme() |> bs_add_rules(".my-tip { max-width: none; }")
+#'   ```
+#'
+#' @section Accessibility of Tooltip Triggers:
+#'
+#'   ```{r child="man/fragments/tooltip-popover_a11y-trigger.Rmd", el = "tooltip"}
+#'   ```
+#'
+#'   ```r
+#'   tooltip(
+#'     bsicons::bs_icon("info-circle", title = "About tooltips."),
+#'     "Text shown in the tooltip."
+#'   )
 #'   ```
 #'
 #' @describeIn tooltip Add a tooltip to a UI element

--- a/man/fragments/tooltip-popover_a11y-trigger.Rmd
+++ b/man/fragments/tooltip-popover_a11y-trigger.Rmd
@@ -10,4 +10,10 @@ One place where it's important to consider the accessibility of the trigger is w
 In these cases, many R packages that provide icons will create an icon element with the assumption that the icon is decorative, which will make it inaccessible to users of assistive technologies.
 
 When using an icon as the primary trigger, ensure that the icon does not have `aria-hidden="true"` or `role="presentation"` attributes.
-For best results, use [bsicons::bs_icon()] and provide a `title` that describes the purpose of the trigger (rather than the icon itself). For example:
+Icon packages typically provide a way to specify a title for the icon, as well as a way to specify that the icon is not decorative.
+The title should be a short description of the purpose of the trigger, rather than a description of the icon itself.
+
+* If you're using [bsicons::bs_icon()], provide a `title`.
+* If you're using [fontawesome::fa()], set `a11y = "sem"` and provide a `title`.
+
+For example:

--- a/man/fragments/tooltip-popover_a11y-trigger.Rmd
+++ b/man/fragments/tooltip-popover_a11y-trigger.Rmd
@@ -1,0 +1,13 @@
+```{r include = FALSE}
+el <- function() knitr::opts_current$get("el")
+```
+
+Because the user needs to interact with the `trigger` element to see the `r el()`, it's best practice to use an element that is typically accessible via keyboard interactions, like a button or a link.
+If you use a non-interactive element, like a `<span>` or text, bslib will automatically add the `tabindex="0"` attribute to the trigger element to make sure that users can reach the element with the keyboard.
+This means that in most cases you can use any element you want as the trigger.
+
+One place where it's important to consider the accessibility of the trigger is when using an icon without any accompanying text.
+In these cases, many R packages that provide icons will create an icon element with the assumption that the icon is decorative, which will make it inaccessible to users of assistive technologies.
+
+When using an icon as the primary trigger, ensure that the icon does not have `aria-hidden="true"` or `role="presentation"` attributes.
+For best results, use [bsicons::bs_icon()] and provide a `title` that describes the purpose of the trigger (rather than the icon itself). For example:

--- a/man/fragments/tooltip-popover_theming.Rmd
+++ b/man/fragments/tooltip-popover_theming.Rmd
@@ -1,0 +1,9 @@
+```{r include = FALSE}
+el <- function() knitr::opts_current$get("el")
+```
+
+Like other bslib components, `r el()`s can be themed by supplying
+[relevant theming variables](https://rstudio.github.io/bslib/articles/bs5-variables/index.html#`r el()`-bg)
+to [bs_theme()],
+which effects styling of every `r el()` on the page.
+To style a _specific_ `r el()` differently from other `r el()`, utilize the `customClass` option:

--- a/man/popover.Rd
+++ b/man/popover.Rd
@@ -72,10 +72,11 @@ focused.
 \section{Theming/Styling}{
 
 
-Like other bslib components, popovers can be themed by supplying \href{https://rstudio.github.io/bslib/articles/bs5-variables/index.html#popover-bg}{relevant theming variables}
-to \code{\link[=bs_theme]{bs_theme()}}, which effects styling of every popover on the page. To
-style a \emph{specific} popover differently from other popovers, utilize the
-\code{customClass} option:
+Like other bslib components, popovers can be themed by supplying
+\href{https://rstudio.github.io/bslib/articles/bs5-variables/index.html#popover-bg}{relevant theming variables}
+to \code{\link[=bs_theme]{bs_theme()}},
+which effects styling of every popover on the page.
+To style a \emph{specific} popover differently from other popover, utilize the \code{customClass} option:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{popover(
   "Trigger", "Popover message",
@@ -86,6 +87,27 @@ style a \emph{specific} popover differently from other popovers, utilize the
 And then add relevant rules to \code{\link[=bs_theme]{bs_theme()}} via \code{\link[=bs_add_rules]{bs_add_rules()}}:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{bs_theme() |> bs_add_rules(".my-pop \{ max-width: none; \}")
+}\if{html}{\out{</div>}}
+}
+
+\section{Accessibility of Popover Triggers}{
+
+
+Because the user needs to interact with the \code{trigger} element to see the popover, it's best practice to use an element that is typically accessible via keyboard interactions, like a button or a link.
+If you use a non-interactive element, like a \verb{<span>} or text, bslib will automatically add the \code{tabindex="0"} attribute to the trigger element to make sure that users can reach the element with the keyboard.
+This means that in most cases you can use any element you want as the trigger.
+
+One place where it's important to consider the accessibility of the trigger is when using an icon without any accompanying text.
+In these cases, many R packages that provide icons will create an icon element with the assumption that the icon is decorative, which will make it inaccessible to users of assistive technologies.
+
+When using an icon as the primary trigger, ensure that the icon does not have \code{aria-hidden="true"} or \code{role="presentation"} attributes.
+For best results, use \code{\link[bsicons:bs_icon]{bsicons::bs_icon()}} and provide a \code{title} that describes the purpose of the trigger (rather than the icon itself). For example:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{popover(
+  bsicons::bs_icon("gear", title = "Settings"),
+  title = "Settings",
+  sliderInput("n", "Number of points", 1, 100, 50)
+)
 }\if{html}{\out{</div>}}
 }
 

--- a/man/popover.Rd
+++ b/man/popover.Rd
@@ -101,10 +101,24 @@ One place where it's important to consider the accessibility of the trigger is w
 In these cases, many R packages that provide icons will create an icon element with the assumption that the icon is decorative, which will make it inaccessible to users of assistive technologies.
 
 When using an icon as the primary trigger, ensure that the icon does not have \code{aria-hidden="true"} or \code{role="presentation"} attributes.
-For best results, use \code{\link[bsicons:bs_icon]{bsicons::bs_icon()}} and provide a \code{title} that describes the purpose of the trigger (rather than the icon itself). For example:
+Icon packages typically provide a way to specify a title for the icon, as well as a way to specify that the icon is not decorative.
+The title should be a short description of the purpose of the trigger, rather than a description of the icon itself.
+\itemize{
+\item If you're using \code{\link[bsicons:bs_icon]{bsicons::bs_icon()}}, provide a \code{title}.
+\item If you're using \code{\link[fontawesome:fa]{fontawesome::fa()}}, set \code{a11y = "sem"} and provide a \code{title}.
+}
+
+For example:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{popover(
   bsicons::bs_icon("gear", title = "Settings"),
+  title = "Settings",
+  sliderInput("n", "Number of points", 1, 100, 50)
+)
+}\if{html}{\out{</div>}}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{popover(
+  fontawesome::fa("gear", a11y = "sem", title = "Settings"),
   title = "Settings",
   sliderInput("n", "Number of points", 1, 100, 50)
 )

--- a/man/tooltip.Rd
+++ b/man/tooltip.Rd
@@ -56,10 +56,11 @@ Display additional information when focusing (or hovering over) a UI element.
 \section{Theming/Styling}{
 
 
-Like other bslib components, tooltips can be themed by supplying \href{https://rstudio.github.io/bslib/articles/bs5-variables/index.html#tooltip-bg}{relevant theming variables}
-to \code{\link[=bs_theme]{bs_theme()}}, which effects styling of every popover on the page. To
-style a \emph{specific} popover differently from other popovers, utilize the
-\code{customClass} option:
+Like other bslib components, tooltips can be themed by supplying
+\href{https://rstudio.github.io/bslib/articles/bs5-variables/index.html#tooltip-bg}{relevant theming variables}
+to \code{\link[=bs_theme]{bs_theme()}},
+which effects styling of every tooltip on the page.
+To style a \emph{specific} tooltip differently from other tooltip, utilize the \code{customClass} option:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{tooltip(
   "Trigger", "Tooltip message",
@@ -70,6 +71,26 @@ style a \emph{specific} popover differently from other popovers, utilize the
 And then add relevant rules to \code{\link[=bs_theme]{bs_theme()}} via \code{\link[=bs_add_rules]{bs_add_rules()}}:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{bs_theme() |> bs_add_rules(".my-tip \{ max-width: none; \}")
+}\if{html}{\out{</div>}}
+}
+
+\section{Accessibility of Tooltip Triggers}{
+
+
+Because the user needs to interact with the \code{trigger} element to see the tooltip, it's best practice to use an element that is typically accessible via keyboard interactions, like a button or a link.
+If you use a non-interactive element, like a \verb{<span>} or text, bslib will automatically add the \code{tabindex="0"} attribute to the trigger element to make sure that users can reach the element with the keyboard.
+This means that in most cases you can use any element you want as the trigger.
+
+One place where it's important to consider the accessibility of the trigger is when using an icon without any accompanying text.
+In these cases, many R packages that provide icons will create an icon element with the assumption that the icon is decorative, which will make it inaccessible to users of assistive technologies.
+
+When using an icon as the primary trigger, ensure that the icon does not have \code{aria-hidden="true"} or \code{role="presentation"} attributes.
+For best results, use \code{\link[bsicons:bs_icon]{bsicons::bs_icon()}} and provide a \code{title} that describes the purpose of the trigger (rather than the icon itself). For example:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tooltip(
+  bsicons::bs_icon("info-circle", title = "About tooltips."),
+  "Text shown in the tooltip."
+)
 }\if{html}{\out{</div>}}
 }
 

--- a/man/tooltip.Rd
+++ b/man/tooltip.Rd
@@ -85,10 +85,23 @@ One place where it's important to consider the accessibility of the trigger is w
 In these cases, many R packages that provide icons will create an icon element with the assumption that the icon is decorative, which will make it inaccessible to users of assistive technologies.
 
 When using an icon as the primary trigger, ensure that the icon does not have \code{aria-hidden="true"} or \code{role="presentation"} attributes.
-For best results, use \code{\link[bsicons:bs_icon]{bsicons::bs_icon()}} and provide a \code{title} that describes the purpose of the trigger (rather than the icon itself). For example:
+Icon packages typically provide a way to specify a title for the icon, as well as a way to specify that the icon is not decorative.
+The title should be a short description of the purpose of the trigger, rather than a description of the icon itself.
+\itemize{
+\item If you're using \code{\link[bsicons:bs_icon]{bsicons::bs_icon()}}, provide a \code{title}.
+\item If you're using \code{\link[fontawesome:fa]{fontawesome::fa()}}, set \code{a11y = "sem"} and provide a \code{title}.
+}
+
+For example:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tooltip(
-  bsicons::bs_icon("info-circle", title = "About tooltips."),
+  bsicons::bs_icon("info-circle", title = "About tooltips"),
+  "Text shown in the tooltip."
+)
+}\if{html}{\out{</div>}}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tooltip(
+  fontawesome::fa("info-circle", title = "About tooltips"),
   "Text shown in the tooltip."
 )
 }\if{html}{\out{</div>}}


### PR DESCRIPTION
Adds a new section to tooltips and popovers on advice for using accessible triggers.

I also consolidated the repetitive parts of our documentation in to Rmd fragments so that we can have both the accessibility and theming docs in both `tooltip()` and `popover()` without literaly repeating the code in two places. This also resolved issues where the word "popover" was used in the `tooltip()` docs.
