### PR TITLE
Update version in `value_box()`'s deprecation method

### DIFF
--- a/R/value-box.R
+++ b/R/value-box.R
@@ -118,7 +118,7 @@ value_box <- function(
   # ---- Theme ----
   if (lifecycle::is_present(theme_color)) {
     lifecycle::deprecate_soft(
-      "0.5.2",
+      "0.6.0",
       "value_box(theme_color =)",
       "value_box(theme =)",
       details = if (!missing(theme)) {


### PR DESCRIPTION
This should cover all relevant occurrences of `0.5.2` and `deprecate_`