### PR TITLE
docs: Use `a11y` arg from docs for tooltip example

### DIFF
--- a/R/tooltip.R
+++ b/R/tooltip.R
@@ -50,7 +50,7 @@
 #'
 #'   ```r
 #'   tooltip(
-#'     fontawesome::fa("info-circle", title = "About tooltips"),
+#'     fontawesome::fa("info-circle", a11y = "sem", title = "About tooltips"),
 #'     "Text shown in the tooltip."
 #'   )
 #'   ```

--- a/man/tooltip.Rd
+++ b/man/tooltip.Rd
@@ -103,7 +103,7 @@ For example:
 }\if{html}{\out{</div>}}
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tooltip(
-  fontawesome::fa("info-circle", title = "About tooltips"),
+  fontawesome::fa("info-circle", a11y = "sem", title = "About tooltips"),
   "Text shown in the tooltip."
 )
 }\if{html}{\out{</div>}}


### PR DESCRIPTION
Related docs: https://github.com/rstudio/bslib/pull/825/files#diff-7e26871f21e46dd166aac31c26b3b59c7a956dbc64a9ed980d2b8509165ec3bbR17

- [x] Docs are built

