### PR TITLE
feat(sidebar): Mobile transition tweaks

### DIFF
--- a/inst/components/scss/sidebar.scss
+++ b/inst/components/scss/sidebar.scss
@@ -307,6 +307,17 @@ $bslib-sidebar-column-sidebar: Min(calc(100% - var(--_icon-size)), var(--_sideba
         > .collapse-toggle { z-index: 1; }
       }
 
+      // Keep toggle on sidebar side when expanded on mobile
+      &:not(.sidebar-right) > .collapse-toggle {
+        left: var(--_icon-size);
+        right: unset;
+      }
+
+      &.sidebar-right > .collapse-toggle {
+        right: var(--_icon-size);
+        left: unset;
+      }
+
       // Either sidebar or main area take up entire layout depending on state
       $full-closed: 100% 0;
       $closed-full: 0 100%;

--- a/inst/components/scss/sidebar.scss
+++ b/inst/components/scss/sidebar.scss
@@ -222,6 +222,11 @@ $bslib-sidebar-column-sidebar: Min(calc(100% - var(--_icon-size)), var(--_sideba
     }
   }
 
+  // hide sidebar content while we transition the parent .sidebar
+  &.transitioning > .sidebar > .sidebar-content {
+    display: none;
+  }
+
   &.sidebar-collapsed {
     --_toggle-transform: 180deg;
     --_toggle-right-transform: 0deg;
@@ -264,14 +269,6 @@ $bslib-sidebar-column-sidebar: Min(calc(100% - var(--_icon-size)), var(--_sideba
       left: calc(-2.5 * var(--_icon-size) - var(--bs-card-border-width, 1px));
       right: unset;
     }
-  }
-}
-
-@include media-breakpoint-up(sm) {
-  // hide sidebar content while we transition the parent .sidebar on desktop
-  // (on mobile the reveal happens immediately)
-  .bslib-sidebar-layout.transitioning > .sidebar > .sidebar-content {
-    display: none;
   }
 }
 

--- a/inst/components/scss/sidebar.scss
+++ b/inst/components/scss/sidebar.scss
@@ -302,7 +302,7 @@ $bslib-sidebar-column-sidebar: Min(calc(100% - var(--_icon-size)), var(--_sideba
 
     &:not([data-bslib-sidebar-open="always"]) {
       // Sidebar layer has to be lifted up to cover other (nested) sidebars
-      &:not(.sidebar-collapsed) {
+      &:not(.sidebar-collapsed), &.transitioning {
         > .sidebar { z-index: 1; }
         > .collapse-toggle { z-index: 1; }
       }


### PR DESCRIPTION
## Transition on mobile

Prior to the sidebar refresh in #798, the sidebar was revealed without transition on mobile devices. In #798 we repositioned the sidebar so that it takes up the entire layout on small screens, using the same transition logic.

An artifact of the previous design was that sidebar content could cause layout shift during transition, because it could affect the size of the parent container. To address that, we hid the sidebar contents until the transition finishes. 

Layout shift isn't a problem on mobile, so it wasn't necessary to update the styles to hide the content. But this makes the transition inconsistent between mobile and desktop, so this PR now hides the content for all sidebars during transition.

## Toggle position on mobile

On mobile or small screens, the sidebar takes up the entire layout container. Depending on the screen size and app layout, this means the sidebar can expand to the entire screen width, taking the toggle with it to the opposite side of the screen.

This PR keeps the toggle on the sidebar's collapsed side on small screens, minimizing mouse or finger travel to open and close the sidebar. This makes use of the dedicated toggle space at the top of the layout container, so it works well for nested sidebars.

## Example

You can see both changes in the video below.