### PR TITLE
fix(shiny-preset): Use tinted color in ionrangeslider handle color on hover

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,8 +54,7 @@ Suggests:
     thematic,
     withr
 Remotes:
-    rstudio/htmltools,
-    rstudio/shiny
+    rstudio/htmltools
 Config/Needs/deploy: 
     BH,
     chiflights22,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,8 @@ Suggests:
     thematic,
     withr
 Remotes:
-    rstudio/htmltools
+    rstudio/htmltools,
+    rstudio/shiny
 Config/Needs/deploy: 
     BH,
     chiflights22,

--- a/inst/builtin/bs5/shiny/ionrangeslider/_variables.scss
+++ b/inst/builtin/bs5/shiny/ionrangeslider/_variables.scss
@@ -12,7 +12,7 @@ $line_bg_color: RGBA($emphasis-color-rgb, 0.65) !default;
 $line_border: none !default;
 
 $handle_color: $component-active-bg !default;
-$handle_color_hover: rgba($handle_color, 0.85) !default;
+$handle_color_hover: tint-color($handle_color, 15%) !default;
 $handle_border: none !default;
 $handle_box_shadow: none !default;
 $handle_radius: $top - 10px !default;


### PR DESCRIPTION
This reverts one small change from #764 to use Sass' `tint-color()` instead of opacity to lighten the handle color.

I think we assumed that `$component-active-bg` uses a CSS variable, but for now it directly uses `$primary`. There's an argument to be made that Bootstrap should use these CSS variables, and I think we should wait for upstream changes rather than patch this highly used variable.