### PR TITLE
tests: Speed up testing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -106,6 +106,8 @@ Config/Needs/website:
     tidyr,
     webshot2
 Config/testthat/edition: 3
+Config/testthat/parallel: true
+Config/testthat/start-first: zzzz-bs-sass, fonts, zzz-precompile, theme-*, rmd-*
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3


### PR DESCRIPTION
Makes two small config changes to cut test time in about half:

1. Enables testing in parallel with testthat.
2. Starts several of the longer-running tests (in particular `zzzz-bs-sass`) first so that one parallel worker handles the longer test.

Separately, I locally added `TESTTHAT_CPUS=5` to my `~/.Renviron`, which allows testthat to use 5 test processes.

On my machine (Mac M1), tests are considerably faster, going from 30+ seconds to 17 second after the change.