### PR TITLE
chore: Move component deps back to page functions

### DIFF
--- a/R/bs-dependencies.R
+++ b/R/bs-dependencies.R
@@ -146,7 +146,6 @@ bs_theme_dependencies <- function(
         meta = list(viewport = "width=device-width, initial-scale=1, shrink-to-fit=no")
       )
     ),
-    if (version >= 5) component_dependencies(),
     htmlDependencies(out_file)
   ))
 }

--- a/R/page.R
+++ b/R/page.R
@@ -25,7 +25,8 @@ page <- function(..., title = NULL, theme = bs_theme(), lang = NULL) {
       tags$body(...),
       title = title,
       theme = theme,
-      lang = lang
+      lang = lang,
+      component_dependencies()
     ),
     theme = theme
   )
@@ -37,7 +38,13 @@ page <- function(..., title = NULL, theme = bs_theme(), lang = NULL) {
 #' @export
 page_fluid <- function(..., title = NULL, theme = bs_theme(), lang = NULL) {
   as_page(
-    shiny::fluidPage(..., title = title, theme = theme, lang = lang),
+    shiny::fluidPage(
+      ...,
+      title = title,
+      theme = theme,
+      lang = lang,
+      component_dependencies()
+    ),
     theme = theme
   )
 }
@@ -49,7 +56,13 @@ page_fluid <- function(..., title = NULL, theme = bs_theme(), lang = NULL) {
 #' @export
 page_fixed <- function(..., title = NULL, theme = bs_theme(), lang = NULL) {
   as_page(
-    shiny::fixedPage(..., title = title, theme = theme, lang = lang),
+    shiny::fixedPage(
+      ...,
+      title = title,
+      theme = theme,
+      lang = lang,
+      component_dependencies()
+    ),
     theme = theme
   )
 }

--- a/tests/testthat/_snaps/page/card.html
+++ b/tests/testthat/_snaps/page/card.html
@@ -7,13 +7,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 <link href="lib/bootstrap/bootstrap.min.css" rel="stylesheet" />
 <script src="lib/bootstrap/bootstrap.bundle.min.js"></script>
-<script src="lib/bslib-component-js/components.min.js"></script>
-<script src="lib/bslib-component-js/web-components.min.js" type="module"></script>
-<link href="lib/bslib-component-css/components.css" rel="stylesheet" />
 <script src="lib/bs3compat/transition.js"></script>
 <script src="lib/bs3compat/tabs.js"></script>
 <script src="lib/bs3compat/bs3compat.js"></script>
 <link href="lib/htmltools-fill/fill.css" rel="stylesheet" />
+<script src="lib/bslib-component-js/components.min.js"></script>
+<script src="lib/bslib-component-js/web-components.min.js" type="module"></script>
+<link href="lib/bslib-component-css/components.css" rel="stylesheet" />
 <script src="lib/bslib-tag-require/tag-require.js"></script>
 
 </head>


### PR DESCRIPTION
This reverts commit 147462a9f4e5629cfe161c5ec015390f97dde1a2 from #810, moving back to including the component deps within bslib's `page_*()` functions, but not in `bs_theme_dependencies()`.

The reason for this change is that most consumers of `bs_theme_dependencies()` (pkgdown, rmarkdown, etc.) are looking for the html dependencies for Bootstrap, not necessarily Bootstrap + bslib's components deps.