### PR TITLE
chore: Move around some Sass lines for readability

### DIFF
--- a/inst/builtin/bs5/shiny/_variables.scss
+++ b/inst/builtin/bs5/shiny/_variables.scss
@@ -120,7 +120,6 @@ $box-shadow-lg:
 $card-border-radius: 8px !default;
 
 // bslib Dashboard Styles
-$bslib-dashboard-design: true !default;
 // "Dashboard" styles give you:
 // * softer borders
 // * white cards
@@ -129,6 +128,7 @@ $bslib-dashboard-design: true !default;
 // * light gray background in the main container(s)
 // * white navbar and title panel
 
+$bslib-dashboard-design: true !default;
 $bslib-enable-shadows: $bslib-dashboard-design !default
 
 $border-color-translucent: if($bslib-dashboard-design, rgba(40, 70, 94, 0.1), null) !default;

--- a/inst/components/scss/value_box.scss
+++ b/inst/components/scss/value_box.scss
@@ -19,9 +19,6 @@ $bslib-value-box-horizontal-break-point: 300px;
     border-color: var(--bslib-value-box-border-color, var(--bslib-value-box-border-color-default));
   }
 
-  container-name: bslib-value-box;
-  container-type: inline-size;
-
   .value-box-grid {
     display: grid;
     grid-template-areas: "left right";
@@ -47,6 +44,9 @@ $bslib-value-box-horizontal-break-point: 300px;
   // But we don't need this for mobile, where we have one box per row. This media query
   // is the inverse of `@include media-breakpoint-down(sm)` but that mixin doesn't work
   // inside nested queries.
+  container-name: bslib-value-box;
+  container-type: inline-size;
+
   @media screen and (min-width: breakpoint-max(sm, $grid-breakpoints)) {
     @container bslib-value-box (max-width: #{$bslib-value-box-horizontal-break-point}) {
       &:not(.showcase-bottom) .value-box-grid {


### PR DESCRIPTION
Follow up from #902 to make two readability changes to the shiny preset and value box Sass code.