### PR TITLE
chore(preset): Adjust navbar-padding-x to match page items

### DIFF
--- a/inst/builtin/bs5/shiny/_variables.scss
+++ b/inst/builtin/bs5/shiny/_variables.scss
@@ -68,6 +68,7 @@ $headings-font-weight: 400 !default;
 
 // Spacing
 $hr-margin-y: 2rem !default;
+$navbar-padding-x: 0.66rem !default;
 
 // Inputs
 $input-btn-font-size: 15px !default;


### PR DESCRIPTION
A small inward nudge in the horizontal padding of the navbar to align the outer edge of the navbar items with the outer edge of key elements in the page content.

|  |  |
|--------|--------|
| Before | ![image](https://github.com/rstudio/bslib/assets/5420529/106e9d62-492a-48bd-8080-b37cf46dd631) |
| After | ![image](https://github.com/rstudio/bslib/assets/5420529/37048402-2672-48bd-9675-9f9b748cbe43) | 