### PR TITLE
chore: Fix and adjust wording in warning message

### DIFF
--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -104,7 +104,9 @@ sidebar <- function(
   open <- rlang::arg_match(open)
 
   if (!is.null(max_height_mobile) && open != "always") {
-    rlang::warn('The `max_height_mobile` argument only applies to when `open = "always"`.')
+    rlang::warn(
+      'The `max_height_mobile` argument only applies to the sidebar when `open = "always"`.'
+    )
     max_height_mobile <- NULL
   }
 


### PR DESCRIPTION
Fixes a wording issue in a warning message when `max_height_mobile` is used in `sidebar()` and `open != "always"`.

```r
# Before
invisible(sidebar(max_height_mobile = 300))
#> Warning message:
#> The `max_height_mobile` argument only applies to when `open = "always"`. 

# After
invisible(sidebar(max_height_mobile = 300))
#> Warning message:
#> The `max_height_mobile` argument only applies to the sidebar when `open = "always"`. 
```