### PR TITLE
fix(infer_window_title): Only add `<title>` if not `NA`

### DIFF
--- a/R/page.R
+++ b/R/page.R
@@ -421,7 +421,7 @@ infer_window_title <- function(title = NULL, window_title = NA) {
     }
   }
 
-  window_title
+  if (!is.na(window_title)) window_title else NULL
 }
 
 


### PR DESCRIPTION
Fixes #932

## Before

```r
withr::with_tempfile("test", {
  ui <- page_sidebar()
  htmltools::save_html(ui, file = test)
  readLines(test)
}) |> 
grep("<title", x = _, value = TRUE)
#> [1] "  <title>NA</title>"
```

## After

```r
withr::with_tempfile("test", {
  ui <- page_sidebar()
  htmltools::save_html(ui, file = test)
  readLines(test)
}) |> 
grep("<title", x = _, value = TRUE)
#> character(0)
```