### PR TITLE
fix(layout_columns): Catch and treat `NA` as expected

### DIFF
--- a/R/layout.R
+++ b/R/layout.R
@@ -288,7 +288,7 @@ layout_columns <- function(
 }
 
 as_col_spec <- function(col_widths, n_kids) {
-  if (is.null(col_widths)) return(NULL)
+  if (is.null(col_widths) || rlang::is_na(col_widths)) return(NULL)
 
   if (!is_breakpoints(col_widths)) {
     col_widths <- breakpoints(md = col_widths)
@@ -327,7 +327,7 @@ as_col_spec <- function(col_widths, n_kids) {
 }
 
 col_widths_attrs <- function(col_spec) {
-  if (is.null(col_spec)) return(NULL)
+  if (is.null(col_spec) || rlang::is_na(col_spec)) return(NULL)
 
   names(col_spec) <- paste0("col-widths-", names(col_spec))
   lapply(col_spec, function(x) {

--- a/tests/testthat/test-layout.R
+++ b/tests/testthat/test-layout.R
@@ -24,6 +24,23 @@ test_that("layout_columns() with col_widths", {
   )
 })
 
+test_that("layout_columns() without `col_widths`", {
+  expect_no_match(
+    format(layout_columns(div())),
+    "col-widths-"
+  )
+
+  expect_no_match(
+    format(layout_columns(div(), col_widths = NULL)),
+    "col-widths-"
+  )
+
+  expect_no_match(
+    format(layout_columns(div(), col_widths = list(NA))),
+    "col-widths-"
+  )
+})
+
 test_that("grid_item_container()", {
   expect_snapshot(
     grid_item_container(


### PR DESCRIPTION
Fixes a small bug I introduced in the refactoring at the end of #931 where we didn't correctly interpret a scalar `NA` as no column spec.

```patch
layout_columns(div(class = "item")) |> format() |> cat()

-<bslib-layout-columns class="bslib-grid grid bslib-mb-spacing html-fill-item" col-widths-md data-require-bs-caller="layout_columns()" data-require-bs-version="5">
+<bslib-layout-columns class="bslib-grid grid bslib-mb-spacing html-fill-item" data-require-bs-caller="layout_columns()" data-require-bs-version="5">
  <div class="bslib-grid-item bslib-gap-spacing html-fill-container">
    <div class="item"></div>
  </div>
</bslib-layout-columns>
```

Note that we were accidentally adding the `col-widths-md` attribute.