### PR TITLE
feat: ensure min/max height args on `value_box()` and column layouts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@
 
 * We increased the spacing between elements just slightly in the Shiny preset. This change is most noticeable in the `layout_columns()` or `layout_column_wrap()` component. In these and other components, you can use `gap` and `padding` arguments to choose your own values, or you can set the `$bslib-spacer` (Sass) or `--bslib-spacer` (CSS) variable. (#998)
 
+* `value_box()`, `layout_columns()` and `layout_column_wrap()` now all have `min_height` and `max_height` arguments. These are useful in filling layouts, like `page_fillable()`, `page_sidebar(fillable = TRUE)` or `page_navbar(fillable = TRUE)`. For example, you can use `layout_columns(min_height = 300)` to ensure that a set of items (likely arranged in a row of columns) don't shrink to less than 300 pixels in height. (#1016)
+
 ## Bug fixes
 
 * `layout_columns()` now always uses a 12-unit grid when the user provides an integer value to `col_widths` for any breakpoint. For example, `breakpoints(md = 3, lg = NA)` will pick a best-fitting layout for large screen sizes using the 12-column grid. Previously, the best fit algorithm might adjust the number of columns as a shortcut to an easy solution. That shortcut is only taken when an auto-fit layout is requested for every breakpoint, e.g. `col_widths = breakpoints(md = NA, lg = NA)` or `col_widths = NA`. (#928)

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,7 @@
 
 * We increased the spacing between elements just slightly in the Shiny preset. This change is most noticeable in the `layout_columns()` or `layout_column_wrap()` component. In these and other components, you can use `gap` and `padding` arguments to choose your own values, or you can set the `$bslib-spacer` (Sass) or `--bslib-spacer` (CSS) variable. (#998)
 
-* `value_box()`, `layout_columns()` and `layout_column_wrap()` now all have `min_height` and `max_height` arguments. These are useful in filling layouts, like `page_fillable()`, `page_sidebar(fillable = TRUE)` or `page_navbar(fillable = TRUE)`. For example, you can use `layout_columns(min_height = 300)` to ensure that a set of items (likely arranged in a row of columns) don't shrink to less than 300 pixels in height. (#1016)
+* `value_box()`, `layout_columns()` and `layout_column_wrap()` now all have `min_height` and `max_height` arguments. These are useful in filling layouts, like `page_fillable()`, `page_sidebar(fillable = TRUE)` or `page_navbar(fillable = TRUE)`. For example, you can use `layout_columns(min_height = 300, max_height = 500)` to ensure that a set of items (likely arranged in a row of columns) are always between 300 and 500 pixels tall. (#1016)
 
 ## Bug fixes
 

--- a/R/layout.R
+++ b/R/layout.R
@@ -37,9 +37,10 @@
 #' @param fillable Whether or not each element is wrapped in a fillable container.
 #' @param height_mobile Any valid CSS unit to use for the height when on mobile
 #'   devices (or narrow windows).
-#' @param max_height,min_height The maximum or minimum height of the layout container.
+#' @param min_height,max_height The maximum or minimum height of the layout container.
 #'   Can be any valid [CSS unit][htmltools::validateCssUnit] (e.g.,
-#'   `max_height="200px"`).  
+#'   `max_height="200px"`). Use these arguments in filling layouts to ensure that a
+#'   layout container doesn't shrink below `min_height` or grow beyond `max_height`.
 #' @inheritParams card
 #' @inheritParams card_body
 #'

--- a/R/layout.R
+++ b/R/layout.R
@@ -37,6 +37,9 @@
 #' @param fillable Whether or not each element is wrapped in a fillable container.
 #' @param height_mobile Any valid CSS unit to use for the height when on mobile
 #'   devices (or narrow windows).
+#' @param max_height,min_height The maximum or minimum height of the layout container.
+#'   Can be any valid [CSS unit][htmltools::validateCssUnit] (e.g.,
+#'   `max_height="200px"`).  
 #' @inheritParams card
 #' @inheritParams card_body
 #'
@@ -74,6 +77,8 @@ layout_column_wrap <- function(
   fillable = TRUE,
   height = NULL,
   height_mobile = NULL,
+  min_height = NULL,
+  max_height = NULL,
   gap = NULL,
   class = NULL
 ) {
@@ -137,7 +142,9 @@ layout_column_wrap <- function(
       # doesn't get inherited in a scenario like layout_column_wrap(height=200, ..., layout_column_wrap(...))
       "--bslib-grid-height" = validateCssUnit(height %||% "auto"),
       "--bslib-grid-height-mobile" = validateCssUnit(height_mobile %||% "auto"),
-      gap = validateCssUnit(gap)
+      gap = validateCssUnit(gap),
+      min_height = validateCssUnit(min_height),
+      max_height = validateCssUnit(max_height)
     ),
     !!!attribs,
     children,
@@ -252,7 +259,9 @@ layout_columns <- function(
   fillable = TRUE,
   gap = NULL,
   class = NULL,
-  height = NULL
+  height = NULL,
+  min_height = NULL,
+  max_height = NULL
 ) {
   args <- separate_arguments(...)
   attribs <- args$attribs
@@ -274,6 +283,8 @@ layout_columns <- function(
     style = css(
       height = validateCssUnit(height),
       gap = validateCssUnit(gap),
+      min_height = validateCssUnit(min_height),
+      max_height = validateCssUnit(max_height)
     ),
     # We don't enable the next option by default, but users could add this
     # attribute to hide the internal elements until after the custom element

--- a/R/value-box.R
+++ b/R/value-box.R
@@ -55,9 +55,11 @@
 #'   `"text-light"`) to customize the background/foreground colors.
 #' @param fill Whether to allow the value box to grow/shrink to fit a fillable
 #'   container with an opinionated height (e.g., `page_fillable()`).
-#' @param max_height The maximum height of the value box or the showcase area.
-#'   Can be any valid [CSS unit][htmltools::validateCssUnit] (e.g.,
-#'   `max_height="200px"`).
+#' @param max_height The maximum height of the `value_box()` or the showcase
+#'   area when used in a `showcase_layout_*()` function. Can be any valid [CSS
+#'   unit][htmltools::validateCssUnit] (e.g., `max_height="200px"`).
+#' @param min_height The minimum height of the values box. Can be any valid [CSS
+#'   unit][htmltools::validateCssUnit] (e.g., `min_height="200px"`).
 #' @inheritParams card
 #' @param theme_color `r lifecycle::badge("deprecated")` Use `theme` instead.
 #'
@@ -97,6 +99,7 @@ value_box <- function(
   theme = NULL,
   height = NULL,
   max_height = NULL,
+  min_height = NULL,
   fill = TRUE,
   class = NULL,
   id = NULL,
@@ -163,6 +166,7 @@ value_box <- function(
     full_screen = full_screen,
     height = height,
     max_height = max_height,
+    min_height = min_height,
     fill = fill,
     style = css(
       color = theme$fg,

--- a/man/layout_column_wrap.Rd
+++ b/man/layout_column_wrap.Rd
@@ -68,9 +68,10 @@ fillable container with an opinionated height (e.g., \code{page_fillable()}).}
 \item{height_mobile}{Any valid CSS unit to use for the height when on mobile
 devices (or narrow windows).}
 
-\item{max_height, min_height}{The maximum or minimum height of the layout container.
+\item{min_height, max_height}{The maximum or minimum height of the layout container.
 Can be any valid \link[htmltools:validateCssUnit]{CSS unit} (e.g.,
-\code{max_height="200px"}).}
+\code{max_height="200px"}). Use these arguments in filling layouts to ensure that a
+layout container doesn't shrink below \code{min_height} or grow beyond \code{max_height}.}
 
 \item{gap}{A \link[htmltools:validateCssUnit]{CSS length unit} defining the
 \code{gap} (i.e., spacing) between elements provided to \code{...}. This argument is only applicable when \code{fillable = TRUE}}

--- a/man/layout_column_wrap.Rd
+++ b/man/layout_column_wrap.Rd
@@ -13,6 +13,8 @@ layout_column_wrap(
   fillable = TRUE,
   height = NULL,
   height_mobile = NULL,
+  min_height = NULL,
+  max_height = NULL,
   gap = NULL,
   class = NULL
 )
@@ -65,6 +67,10 @@ fillable container with an opinionated height (e.g., \code{page_fillable()}).}
 
 \item{height_mobile}{Any valid CSS unit to use for the height when on mobile
 devices (or narrow windows).}
+
+\item{max_height, min_height}{The maximum or minimum height of the layout container.
+Can be any valid \link[htmltools:validateCssUnit]{CSS unit} (e.g.,
+\code{max_height="200px"}).}
 
 \item{gap}{A \link[htmltools:validateCssUnit]{CSS length unit} defining the
 \code{gap} (i.e., spacing) between elements provided to \code{...}. This argument is only applicable when \code{fillable = TRUE}}

--- a/man/layout_columns.Rd
+++ b/man/layout_columns.Rd
@@ -69,9 +69,10 @@ fillable container with an opinionated height (e.g., \code{page_fillable()}).}
 \code{height="200px"}). Doesn't apply when a card is made \code{full_screen}
 (in this case, consider setting a \code{height} in \code{\link[=card_body]{card_body()}}).}
 
-\item{max_height, min_height}{The maximum or minimum height of the layout container.
+\item{min_height, max_height}{The maximum or minimum height of the layout container.
 Can be any valid \link[htmltools:validateCssUnit]{CSS unit} (e.g.,
-\code{max_height="200px"}).}
+\code{max_height="200px"}). Use these arguments in filling layouts to ensure that a
+layout container doesn't shrink below \code{min_height} or grow beyond \code{max_height}.}
 }
 \description{
 Create responsive, column-based grid layouts, based on a 12-column grid.

--- a/man/layout_columns.Rd
+++ b/man/layout_columns.Rd
@@ -12,7 +12,9 @@ layout_columns(
   fillable = TRUE,
   gap = NULL,
   class = NULL,
-  height = NULL
+  height = NULL,
+  min_height = NULL,
+  max_height = NULL
 )
 }
 \arguments{
@@ -66,6 +68,10 @@ fillable container with an opinionated height (e.g., \code{page_fillable()}).}
 \item{height}{Any valid \link[htmltools:validateCssUnit]{CSS unit} (e.g.,
 \code{height="200px"}). Doesn't apply when a card is made \code{full_screen}
 (in this case, consider setting a \code{height} in \code{\link[=card_body]{card_body()}}).}
+
+\item{max_height, min_height}{The maximum or minimum height of the layout container.
+Can be any valid \link[htmltools:validateCssUnit]{CSS unit} (e.g.,
+\code{max_height="200px"}).}
 }
 \description{
 Create responsive, column-based grid layouts, based on a 12-column grid.

--- a/man/value_box.Rd
+++ b/man/value_box.Rd
@@ -18,6 +18,7 @@ value_box(
   theme = NULL,
   height = NULL,
   max_height = NULL,
+  min_height = NULL,
   fill = TRUE,
   class = NULL,
   id = NULL,
@@ -77,9 +78,10 @@ control, you can create your own theme with \code{value_box_theme()} where you
 can pass foreground and background colors directly. See the \strong{Themes}
 section for more details.}
 
-\item{max_height}{The maximum height of the value box or the showcase area.
-Can be any valid \link[htmltools:validateCssUnit]{CSS unit} (e.g.,
-\code{max_height="200px"}).}
+\item{max_height}{The maximum height of the \code{value_box()} or the showcase
+area when used in a \verb{showcase_layout_*()} function. Can be any valid \link[htmltools:validateCssUnit]{CSS unit} (e.g., \code{max_height="200px"}).}
+
+\item{min_height}{The minimum height of the values box. Can be any valid \link[htmltools:validateCssUnit]{CSS unit} (e.g., \code{min_height="200px"}).}
 
 \item{fill}{Whether to allow the value box to grow/shrink to fit a fillable
 container with an opinionated height (e.g., \code{page_fillable()}).}


### PR DESCRIPTION
Fixes #973 #974

* Adds `min_height` to `value_box()`
* Adds `min_height` and `max_height` to `layout_columns()` and `layout_column_wrap()`

## Example

<details>
<summary>Example App</summary>

```r
library(shiny)
library(bslib)
library(ggplot2)

data(penguins, package = "palmerpenguins")

# Calculate column means for the value boxes
means <- colMeans(
  penguins[c("bill_length_mm", "bill_length_mm", "body_mass_g")],
  na.rm = TRUE
)

ui <- page_sidebar(
  title = "Penguins dashboard",
  sidebar = sidebar(
    varSelectInput(
      "color_by", "Color by",
      penguins[c("species", "island", "sex")],
      selected = "species"
    )
  ),
  layout_columns(
    fill = FALSE,
    value_box(
      title = "Average bill length",
      value = scales::unit_format(unit = "mm")(means[[1]]),
      showcase = bsicons::bs_icon("align-bottom")
    ),
    value_box(
      title = "Average bill depth",
      value = scales::unit_format(unit = "mm")(means[[2]]),
      showcase = bsicons::bs_icon("align-center"),
      theme_color = "dark"
    ),
    value_box(
      title = "Average body mass",
      value = scales::unit_format(unit = "g", big.mark = ",")(means[[3]]),
      showcase = bsicons::bs_icon("handbag"),
      theme_color = "secondary"
    )
  ),
  layout_columns(
    min_height = 300, #<<
    max_height = 400, #<<
    card(
      full_screen = TRUE,
      card_header("Bill Length"),
      plotOutput("bill_length")
    ),
    card(
      full_screen = TRUE,
      card_header("Bill depth"),
      plotOutput("bill_depth")
    )
  ),
  card(
    min_height = 400, #<<
    full_screen = TRUE,
    card_header("Body Mass"),
    plotOutput("body_mass")
  )
)

server <- function(input, output) {
  gg_plot <- reactive({
    ggplot(penguins) +
      geom_density(aes(fill = !!input$color_by), alpha = 0.2) +
      theme_bw(base_size = 16) +
      theme(axis.title = element_blank())
  })

  output$bill_length <- renderPlot(gg_plot() + aes(bill_length_mm))
  output$bill_depth <- renderPlot(gg_plot() + aes(bill_depth_mm))
  output$body_mass <- renderPlot(gg_plot() + aes(body_mass_g))
}

shinyApp(ui, server)
```
</details>

The example app above has three rows of elements in a fillable `page_sidebar()` container. Without adding `min_height` anywhere in the UI, at small screen heights the app looks like this:

![image](https://github.com/rstudio/bslib/assets/5420529/b17529c6-0b6b-451c-9974-3f367fe3abb9)

Adding `min_height = 300` to the `layout_columns()` with the two plots and `min_height = 400` to the final card, we now have a layout that scrolls at small screen heights.

![image](https://github.com/rstudio/bslib/assets/5420529/9f793a12-093a-4610-8134-8a2429ca9d4d)
