### PR TITLE
fix(themer): Set dark mode correctly for preview

### DIFF
--- a/inst/themer/themer.js
+++ b/inst/themer/themer.js
@@ -228,7 +228,8 @@
   });
 
   $(document).on("change", "#bsthemer-dark-mode", function(ev) {
-    document.body.dataset.bsTheme = ev.target.checked ? "dark" : "light";
+    const colorMode = ev.target.checked ? "dark" : "light";
+    document.documentElement.dataset.bsTheme = colorMode;
     $(window).resize();
   });
 


### PR DESCRIPTION
Correctly preview dark mode by setting `data-bs-theme` on `document.documentElement` instead of `document.body`.
