### PR TITLE
docs(value-box): Replace ResizeObserver with `bslib.card` event listener

### DIFF
--- a/vignettes/value-boxes/index.Rmd
+++ b/vignettes/value-boxes/index.Rmd
@@ -223,11 +223,10 @@ sparkline <- plot_ly(economics) %>%
   config(displayModeBar = F) %>%
   htmlwidgets::onRender(
     "function(el) {
-      var ro = new ResizeObserver(function() {
-         var visible = el.offsetHeight > 200;
-         Plotly.relayout(el, {'xaxis.visible': visible});
-      });
-      ro.observe(el);
+      el.closest('.bslib-value-box')
+        .addEventListener('bslib.card', function(ev) {
+          Plotly.relayout(el, {'xaxis.visible': ev.detail.fullScreen});
+        })
     }"
   )
 


### PR DESCRIPTION
Inspired by #1036, this replaces the `ResizeObserver` used to adjust the plot layout in full screen mode with a simpler `bslib.card` event handler.