### PR TITLE
feat: Keep attrs on `.main` of `page_sidebar()`

### DIFF
--- a/R/page.R
+++ b/R/page.R
@@ -275,6 +275,8 @@ page_sidebar <- function(
 
   sidebar <- maybe_page_sidebar(sidebar)
 
+  dots <- separate_arguments(...)
+
   page_fillable(
     padding = 0,
     gap = 0,
@@ -289,7 +291,8 @@ page_sidebar <- function(
       fillable = fillable,
       border = FALSE,
       border_radius = FALSE,
-      page_sidebar_main(...)
+      !!!dots$attribs,
+      page_sidebar_main(dots$children)
     )
   )
 }
@@ -297,7 +300,7 @@ page_sidebar <- function(
 page_sidebar_main <- function(...) {
   as_fill_carrier(
     div(
-      class = "bslib-page-sidebar-main bslib-gap-spacing", 
+      class = "bslib-page-sidebar-main bslib-gap-spacing",
       ...
     )
   )

--- a/tests/testthat/_snaps/page.md
+++ b/tests/testthat/_snaps/page.md
@@ -33,8 +33,8 @@
 ---
 
     Code
-      renderTags(page_sidebar("main", title = "Title", sidebar = sidebar(open = "always")))$
-        html
+      renderTags(page_sidebar("main", title = "Title", sidebar = sidebar(open = "always"),
+      `data-attr` = "here"))$html
     Output
       <body class="bslib-page-fill bslib-gap-spacing bslib-flow-mobile bslib-page-sidebar html-fill-container" style="padding:0px;gap:0px;">
         <div class="navbar navbar-static-top">
@@ -43,7 +43,7 @@
           </div>
         </div>
         <div class="bslib-sidebar-layout bslib-mb-spacing html-fill-item" data-bslib-sidebar-border="false" data-bslib-sidebar-border-radius="false" data-bslib-sidebar-init="TRUE" data-collapsible-desktop="false" data-collapsible-mobile="false" data-open-desktop="always" data-open-mobile="always" data-require-bs-caller="layout_sidebar()" data-require-bs-version="5" style="--_sidebar-width:250px;">
-          <div class="main bslib-gap-spacing html-fill-container">
+          <div class="main bslib-gap-spacing html-fill-container" data-attr="here">
             <div class="bslib-page-sidebar-main bslib-gap-spacing html-fill-item html-fill-container">main</div>
           </div>
           <aside class="sidebar">

--- a/tests/testthat/test-page.R
+++ b/tests/testthat/test-page.R
@@ -55,7 +55,8 @@ test_that("page_sidebar()", {
         "main",
         title = "Title",
         # Removes the {bsicons} icon
-        sidebar = sidebar(open = "always")
+        sidebar = sidebar(open = "always"),
+        "data-attr" = "here"
       )
     )$html,
     cran = TRUE


### PR DESCRIPTION
Follow up for #1057 to ensure attributes stay on the `.main` container, children are passed into the `.bslib-page-sidebar-main` container.

Not needed for `page_navbar()` where attributes and children end up in the nav panel container.