### PR TITLE
fix: Don't add `bslib-gap-spacing` when card body is not fillable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 * The main content area of `page_sidebar()` and `page_navbar()` with a `sidebar` now have a minimum height and width to avoid squashed content in fillable layouts. The minimum height and width are controllable via Sass and CSS variables (see the pull requests for details). (#1057, #1059)
 
+* When `card_body(fillable = FALSE)`, bslib now preserves flow-layout margin bottom settings. (#1073)
+
 # bslib 0.7.0
 
 This large release includes many improvements and bug fixes for newer UI components like `layout_columns()`, `card()`, and `sidebar()`. In addition, the new `input_task_button()` offers a drop-in replacement for `shiny::actionButton()` (to prevent multiple submissions of the same operation) as well as pairing nicely with the new `shiny::ExtendedTask` for implementing truly non-blocking operations in Shiny.

--- a/R/card.R
+++ b/R/card.R
@@ -197,7 +197,8 @@ card_body <- function(..., fillable = TRUE, min_height = NULL, max_height = NULL
   }
 
   tag <- div(
-    class = "card-body bslib-gap-spacing",
+    class = "card-body",
+    class = if (fillable) "bslib-gap-spacing",
     style = css(
       min_height = validateCssUnit(min_height),
       "--bslib-card-body-max-height" = validateCssUnit(max_height),

--- a/R/layout.R
+++ b/R/layout.R
@@ -389,7 +389,8 @@ row_heights_css_vars <- function(x) {
 grid_item_container <- function(el, ..., fillable = TRUE) {
   div(
     ...,
-    class = "bslib-grid-item bslib-gap-spacing",
+    class = "bslib-grid-item",
+    class = if (fillable) "bslib-gap-spacing",
     if (fillable) as_fillable_container(),
     el
   )

--- a/tests/testthat/_snaps/layout.md
+++ b/tests/testthat/_snaps/layout.md
@@ -92,7 +92,7 @@
     Code
       grid_item_container(div(class = "layout-column-child-element"), fillable = FALSE)
     Output
-      <div class="bslib-grid-item bslib-gap-spacing">
+      <div class="bslib-grid-item">
         <div class="layout-column-child-element"></div>
       </div>
 


### PR DESCRIPTION
When `card_body(fillable = FALSE, ...)` we should not be adding the `bslib-gap-spacing` class to the card body container.

<details>
<summary>App Example</summary>

```r
library(shiny)
# library(bslib)
pkgload::load_all()
library(leaflet)

ui <- page_fillable(
  card(
    class = "text-bg-light",
    # max_height = "400px",
    card_body(
      fillable = FALSE,
      h3("Lehigh University"),
      lorem::ipsum(3, 1:3 + 1),
      actionButton("visit", "Visit School")
    ),
    card_body(
      leafletOutput("map_lehigh"),
    )
  )
)

server <- function(input, output, session) {
  output$map_lehigh <- renderLeaflet({
    lat  <- 40.60682
    long <- -75.38024
    name <- "Lehigh University"

    leaflet() |>
      addTiles() |>
      setView(lng = long, lat = lat, zoom = 13) |>
      addMarkers(lng = long, lat = lat, popup = name)
  })
}

shinyApp(ui, server)
```

</details>

| Before | After |
|:--:|:--:|
| ![image](https://github.com/rstudio/bslib/assets/5420529/012aa12f-4396-43e7-a94c-7c8edaf1c20a) | ![image](https://github.com/rstudio/bslib/assets/5420529/eef4ae43-e99e-42f6-a430-6068678e664e) |
