### PR TITLE
fix(page_sidebar): Use `rlang::exec()` to ensure spliced attributes are treated as arguments

### DIFF
--- a/R/page.R
+++ b/R/page.R
@@ -283,6 +283,15 @@ page_sidebar <- function(
 
   dots <- separate_arguments(...)
 
+  layout_sidebar_args <- rlang::list2(
+    sidebar = sidebar,
+    fillable = fillable,
+    border = FALSE,
+    border_radius = FALSE,
+    !!!dots$attribs,
+    page_main_container(dots$children)
+  )
+
   page_fillable(
     padding = 0,
     gap = 0,
@@ -292,14 +301,7 @@ page_sidebar <- function(
     fillable_mobile = fillable_mobile,
     class = "bslib-page-sidebar",
     navbar_title,
-    layout_sidebar(
-      sidebar = sidebar,
-      fillable = fillable,
-      border = FALSE,
-      border_radius = FALSE,
-      !!!dots$attribs,
-      page_main_container(dots$children)
-    )
+    rlang::exec(layout_sidebar, !!!layout_sidebar_args)
   )
 }
 


### PR DESCRIPTION
#1058 introduced a subtle issue that spliced attributes weren't being treated as arguments to `layout_sidebar()` in `page_sidebar()`.

This PR uses `rlang::exec()` to avoid that problem.

Currently, with bslib from main, the following does not work (the main content area is not white text on a purple background).

```r
library(shiny)
library(bslib)
# pkgload::load_all()


ui <- page_sidebar(
  bg = "purple",
  fg = "white",
  "Content here"
)

shinyApp(ui, \(...) { })
```