### PR TITLE
fix(safari): Use `-webkit-` prefix for `backdrop-filter` (Take 2)

### DIFF
--- a/inst/builtin/bs5/shiny/_rules.scss
+++ b/inst/builtin/bs5/shiny/_rules.scss
@@ -288,6 +288,7 @@ $icon-classes: ("bi", "fa", "fas", "far", "fab", "material-icons") !default;
 #shiny-modal-wrapper:has( ~ .modal-backdrop) .modal {
   // Blur the background when the modal has a backdrop
   backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
 }
 
 // Progress Bars & Notifications

--- a/inst/components/scss/sidebar.scss
+++ b/inst/components/scss/sidebar.scss
@@ -89,7 +89,6 @@ $bslib-sidebar-column-sidebar: Min(calc(100% - var(--_padding-icon)), var(--_sid
     border-bottom-right-radius: 0;
     color: var(--_sidebar-fg);
     background-color: var(--_sidebar-bg);
-    backdrop-filter: blur(5px);
 
     > .sidebar-content {
       display: flex;
@@ -333,6 +332,8 @@ $bslib-sidebar-column-sidebar: Min(calc(100% - var(--_padding-icon)), var(--_sid
       }
 
       > .sidebar {
+        backdrop-filter: blur(6px);
+        -webkit-backdrop-filter: blur(6px);
         opacity: var(--_sidebar-mobile-opacity, 1);
         max-width: var(--_sidebar-mobile-max-width, 100%);
         box-shadow: var(--_sidebar-mobile-box-shadow);
@@ -371,7 +372,7 @@ $bslib-sidebar-column-sidebar: Min(calc(100% - var(--_padding-icon)), var(--_sid
 
       // Soften main area when sidebar is expanded over content
       > .main {
-        opacity: 0.33;
+        opacity: 0.2;
         transition: opacity var(--_transition-easing-x) var(--_transition-duration);
       }
       &.sidebar-collapsed > .main {

--- a/inst/components/scss/sidebar.scss
+++ b/inst/components/scss/sidebar.scss
@@ -378,6 +378,11 @@ $bslib-sidebar-column-sidebar: Min(calc(100% - var(--_padding-icon)), var(--_sid
       &.sidebar-collapsed > .main {
         opacity: 1;
       }
+
+      // Move main bg to layout container
+      &:not(.sidebar-collapsed) {
+        background-color: var(--_main-bg);
+      }
     }
   }
 }

--- a/inst/components/scss/sidebar.scss
+++ b/inst/components/scss/sidebar.scss
@@ -1,6 +1,6 @@
 // User-facing variables, use for theming
 $bslib-sidebar-bg: rgba(var(--bs-emphasis-color-rgb, 0,0,0), 0.05) !default;
-$bslib-sidebar-fg: null !default;
+$bslib-sidebar-fg: var(--_main-fg) !default;
 $bslib-sidebar-toggle-bg: rgba(var(--bs-emphasis-color-rgb, 0,0,0), 0.1) !default;
 $bslib-sidebar-border: var(--bs-card-border-width, #{$card-border-width}) solid var(--bs-card-border-color, #{$card-border-color}) !default;
 


### PR DESCRIPTION
This is a second-take on #1080

> Add missing `-webkit-` prefixed `backdrop-filter` rule for Safari. Also tweaks blur and opactiy to make the effect a little bit more subtle.
> 
> For context, the blur/opacity appears when the sidebar is collapsible on mobile. In this case, the sidebar expands to cover the content in the layout, and the goal is to give the user the sense that the covered outputs are updating when the inputs in the sidebar are changed.
> 
> Note: the next release of Safari won't require this. In general, backdrop-filter is well supported (96.57%, all major browsers in the last 2 years).

Summarizing some of the conversation in #1080, we're stuck with transparent sidebars -- it's better as a default to let the underlying colors pass through than to set a fixed opaque color for the sidebar. This creates issues when the sidebar is collapsible on mobile because the open sidebar is overlaid on the main container. The solution to that design decision was to make the main container almost completely transparent and to add a blur effect.

This PR fixes two issues with that approach:

1. `backdrop-filter` requires a `-webkit-` prefix on Safari.
2. When the sidebar layout's main content area _has a background color_, we would lose that color when fading out the main area. We now reflect the main bg color to the layout container when the sidebar is expanded so that we don't lose that background color.

In #1080 I explored using `color-mix()` but it greatly increased the complexity with very littly benefit. Because we don't always know (i.e. have available as a CSS property) the background color of the containers underneath the sidebar container, we still rely on transparency and we end up having the same problems as listed above.

I also explored using a backdrop element below the expanded sidebar, but we again run into problems with needing to know the background color underneath the sidebar layout.