### PR TITLE
fix(page): Allow empty dots in page functions

### DIFF
--- a/R/page.R
+++ b/R/page.R
@@ -43,12 +43,12 @@ page <- function(..., title = NULL, theme = bs_theme(), lang = NULL) {
 page_fluid <- function(..., title = NULL, theme = bs_theme(), lang = NULL) {
   as_page(
     shiny::fluidPage(
+      # Components require Bootstrap 5+
+      if (isTRUE(theme_version(theme) >= 5)) component_dependencies(),
       ...,
       title = title,
       theme = theme,
-      lang = lang,
-      # Components require Bootstrap 5+
-      if (isTRUE(theme_version(theme) >= 5)) component_dependencies()
+      lang = lang
     ),
     theme = theme
   )
@@ -62,12 +62,12 @@ page_fluid <- function(..., title = NULL, theme = bs_theme(), lang = NULL) {
 page_fixed <- function(..., title = NULL, theme = bs_theme(), lang = NULL) {
   as_page(
     shiny::fixedPage(
+      # Components require Bootstrap 5+
+      if (isTRUE(theme_version(theme) >= 5)) component_dependencies(),
       ...,
       title = title,
       theme = theme,
-      lang = lang,
-      # Components require Bootstrap 5+
-      if (isTRUE(theme_version(theme) >= 5)) component_dependencies()
+      lang = lang
     ),
     theme = theme
   )
@@ -186,9 +186,9 @@ page_fillable <- function(
       padding = validateCssPadding(padding),
       gap = validateCssUnit(gap)
     ),
-    ...,
+    as_fillable_container(),
     tags$head(tags$style("html { height: 100%; }")),
-    as_fillable_container()
+    ...
   )
 }
 

--- a/tests/testthat/test-page.R
+++ b/tests/testthat/test-page.R
@@ -102,3 +102,25 @@ test_that("save_html() works on components and pages with a custom theme", {
     expect_snapshot_file("modern-page.html")
   })
 })
+
+
+test_that("page_*() functions can handle trailing commas", {
+  expect_no_error(
+    page("foo",)
+  )
+  expect_no_error(
+    page_fluid("foo",)
+  )
+  expect_no_error(
+    page_fixed("foo",)
+  )
+  expect_no_error(
+    page_fillable("foo",)
+  )
+  expect_no_error(
+    page_sidebar("foo",)
+  )
+  expect_no_error(
+    page_navbar(nav_panel("foo", "bar"),)
+  )
+})


### PR DESCRIPTION
This fixes allowing trailing empty arguments in all of the page functions. This was broken in several page functions because the dots must come _after_ unnamed arguments in the calling functions.

## Problem

Here's a minimal reprex that demonstrates the problematic pattern we were using:

```r
page_one <- function(...) {
  bslib::page(..., "b",)
}

page_two <- function(...) {
  bslib::page("b", ...)
}

as.character(page_one("a", ))
#> Error in `dots_list()`:
#> ! Argument 2 can't be empty.
as.character(page_two("a", ))
#> [1] "<body>\n  b\n  a\n</body>"
```

In reality, we're not adding content but rather we're adding an unnamed dependency object (in the place of `"b"` above).

## Before

```r
library(bslib)
x <- "test"

page(x, ) |> print(browse = FALSE)
#> <body>test</body>

page_fillable(x, ) |> print(browse = FALSE)
#> Error in `dots_list()`:
#> ! Argument 5 can't be empty.

page_fixed(x, ) |> print(browse = FALSE)
#> Error in `dots_list()`:
#> ! Argument 3 can't be empty.

page_fluid(x, ) |> print(browse = FALSE)
#> Error in `dots_list()`:
#> ! Argument 3 can't be empty.

page_navbar(nav_panel(x), ) |> print(browse = FALSE)
#> <body class="bslib-page-fill bslib-gap-spacing bslib-flow-mobile bslib-page-navbar html-fill-container" style="padding:0px;gap:0px;">
#>   [...clip...]
#> </body>
page_sidebar(x, ) |> print(browse = FALSE)
#> <body class="bslib-page-fill bslib-gap-spacing bslib-flow-mobile bslib-page-sidebar html-fill-container" style="padding:0px;gap:0px;">
#>   [...clip...]
#> </body>
```

## After

``` r
pkgload::load_all()
#> ℹ Loading bslib
x <- "test"

page(x, ) |> print(browse = FALSE)
#> <body>test</body>

page_fillable(x, ) |> print(browse = FALSE)
#> <body class="bslib-page-fill bslib-gap-spacing bslib-flow-mobile html-fill-container">test</body>

page_fixed(x, ) |> print(browse = FALSE)
#> <div class="container">test</div>

page_fluid(x, ) |> print(browse = FALSE)
#> <div class="container-fluid">test</div>

page_navbar(nav_panel(x), ) |> print(browse = FALSE)
#> <body class="bslib-page-fill bslib-gap-spacing bslib-flow-mobile html-fill-container bslib-page-navbar" style="padding:0px;gap:0px;">
#>   [...clip...]
#> </body>

page_sidebar(x, ) |> print(browse = FALSE)
#> <body class="bslib-page-fill bslib-gap-spacing bslib-flow-mobile html-fill-container bslib-page-sidebar" style="padding:0px;gap:0px;">
#>   [...clip...]
#> </body>
```