### PR TITLE
`bs_themer()` fixed to prevent NULL values from crashing themer, fix …

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * `navset_card_pills()`, `navset_card_underline()`, `navset_card_tabs()` fixed to now respect header/footer arguments (@tanho63, #1024) 
 
-* Fixed a bug in `bs_themer()` that caused it to stop applying changes if a Sass variable was `NULL`. (@meztez, #1112)
+* Fixed a bug in `bs_themer()` (and `bs_theme_preview()`) that caused it to stop applying changes if a Sass variable was `NULL`. (@meztez, #1112)
 
 # bslib 0.8.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * `navset_card_pills()`, `navset_card_underline()`, `navset_card_tabs()` fixed to now respect header/footer arguments (@tanho63, #1024) 
 
-* `bs_themer()` fixed to prevent NULL values from crashing themer, fix #1111. (@meztez, #1112).
+* Fixed a bug in `bs_themer()` that caused it to stop applying changes if a Sass variable was `NULL`. (@meztez, #1112)
 
 # bslib 0.8.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `navset_card_pills()`, `navset_card_underline()`, `navset_card_tabs()` fixed to now respect header/footer arguments (@tanho63, #1024) 
 
+* `bs_themer()` fixed to prevent NULL values from crashing themer, fix #1111. (@meztez, #1112).
+
 # bslib 0.8.0
 
 ## Breaking changes

--- a/R/bs-theme-preview.R
+++ b/R/bs-theme-preview.R
@@ -411,7 +411,7 @@ bs_themer <- function(gfonts = TRUE, gfonts_update = FALSE) {
     # Validate that `vals` is a simple list, containing atomic elements,
     # that are all named
     if (!identical(class(vals), "list") ||
-        !all(vapply(vals, is.atomic, logical(1))) ||
+        !all(vapply(vals, function(x) {is.atomic(x) || is.null(x)}, logical(1))) ||
         is.null(names(vals)) ||
         !isTRUE(all(nzchar(names(vals), keepNA = TRUE)))) {
       warning(call. = FALSE,


### PR DESCRIPTION
…#1111.

Reproduce.
run
```r
bslib::bs_theme_preview()
```
Change background color from theme customizer menu.

The changes will not be applied since parsing from input$bs_theme_preset will yield a NULL value for `headings-font-family` key.

The change here is to allow NULL in the condition check. Not sure if it is a valid solution for every possible case.

in : https://github.com/rstudio/bslib/blob/5420b24210a1d82062490b33e4d37f438467fd88/R/bs-theme-preview.R#L414

# Pull Request

- [x] Ensure there is an already open and relevant [GitHub issue](https://github.com/rstudio/bslib/issues/new) describing the problem in detail and you've already received some indication from the maintainers that they are welcome to a contribution to fix the problem. This helps us to prevent wasting anyone's time. 

- [ ] Add unit tests in the tests/testthat directory.

- [ ] This project uses [roxygen2 for documentation](http://r-pkgs.had.co.nz/man.html). If you've made changes to documentation, run `devtools::document()`.

- [ ] Run `devtools::check()` (or, equivalently, click on Build->Check Package in the RStudio IDE) to make sure your change did not add any messages, warnings, or errors.
    * Note there is a decent chance that some tests were already failing before your changes. Just make sure you haven't introduced any new ones.
    
- [x] Ensure your code changes follow the style outlined in http://r-pkgs.had.co.nz/style.html

- [x] Add an entry to NEWS.md concisely describing what you changed.
