### PR TITLE
brand: Use download button in example app when deployed

### DIFF
--- a/inst/examples-shiny/brand.yml/app.R
+++ b/inst/examples-shiny/brand.yml/app.R
@@ -57,7 +57,26 @@ ui <- page_navbar(
 		bg = "#0D1117",
 		
 		card(
-			card_header("Edit", code("brand.yml"), class = "text-bg-secondary"),
+			card_header(
+				class = "text-bg-secondary hstack",
+				div("Edit", code("brand.yml")),
+				div(
+					class = "ms-auto",
+					tooltip(
+						tags$a(
+							class = "btn btn-link p-0",
+							href = "https://posit-dev.github.io/brand-yml/brand/",
+							target = "_blank",
+							bsicons::bs_icon(
+								"question-square-fill",
+								title = "About brand.yml",
+								size = "1.25rem"
+							)
+						),
+						"About brand.yml"
+					)
+				)
+			),
 			htmltools::tagAppendAttributes(
 				textAreaInput(
 					"txt_brand_yml",

--- a/inst/examples-shiny/brand.yml/app.R
+++ b/inst/examples-shiny/brand.yml/app.R
@@ -54,7 +54,8 @@ ui <- page_navbar(
 		position = "right",
 		open = "closed",
 		width = "40%",
-		bg = "#0D1117",
+		bg = "var(--bs-dark)",
+		fg = "var(--bs-light)",
 		
 		card(
 			card_header(

--- a/inst/examples-shiny/brand.yml/app.R
+++ b/inst/examples-shiny/brand.yml/app.R
@@ -138,7 +138,13 @@ initBrandEditor()'
 			)
 		),
 
-		if (getwd() != system.file("examples-shiny/brand.yml", package = "bslib")) {
+		if (Sys.getenv("R_CONFIG_ACTIVE") %in% c("shinylive", "shinyapps", "rsconnect", "rstudio_cloud")) {
+			shiny::downloadButton(
+				"download",
+				label = span("Download", code("_brand.yml"), "file"),
+				class = "btn-outline-light"
+			)
+		} else if (getwd() != system.file("examples-shiny/brand.yml", package = "bslib")) {
 			actionButton(
 				"save",
 				label = span("Save", code("_brand.yml"), "file"),
@@ -392,10 +398,10 @@ server <- function(input, output, session) {
 	})
 
 	observeEvent(input$save, {
-		req(brand_yml())
+		validate(
+			need(input$txt_brand_yml, "_brand.yml file contents cannot be empty.")
+		)
 
-		b <- brand_yml()
-		b$path <- NULL
 		tryCatch(
 			{
 				writeLines(input$txt_brand_yml, "_brand.yml")
@@ -404,6 +410,16 @@ server <- function(input, output, session) {
 			error = error_notification("Could not save `_brand.yml`.")
 		)
 	})
+
+	output$download <- downloadHandler(
+		filename = "_brand.yml",
+		content = function(file) {
+			validate(
+				need(input$txt_brand_yml, "_brand.yml file contents cannot be empty.")
+			)
+			writeLines(input$txt_brand_yml, file)
+		}
+	)
 
 	PlotTask <- ExtendedTask$new(function(x_max, y_factor) {
 		x <- seq(0, x_max, length.out = 100)

--- a/inst/examples-shiny/brand.yml/app.R
+++ b/inst/examples-shiny/brand.yml/app.R
@@ -138,13 +138,13 @@ initBrandEditor()'
 			)
 		),
 
-		# if (getwd() != system.file("examples-shiny/brand.yml", package = "bslib")) {
-		actionButton(
-			"save",
-			label = span("Save", code("_brand.yml"), "file"),
-			class = "btn-outline-light"
-		)
-		# }
+		if (getwd() != system.file("examples-shiny/brand.yml", package = "bslib")) {
+			actionButton(
+				"save",
+				label = span("Save", code("_brand.yml"), "file"),
+				class = "btn-outline-light"
+			)
+		}
 	),
 
 	nav_panel(


### PR DESCRIPTION
- feat: Add link to editor header to brand.yml structure
- chore: restore code to avoid saving if running in pkg dir
- feat: Use a download button if deployed on posit hosted products
- chore: Use dark bg color for sidebar
