### PR TITLE
docs: Discuss BS5 with Bootswatch in `?navbar_options`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
    Related to the above change, `navset_bar()` now defaults to using `underline = TRUE` so that both `page_navbar()` and `navset_bar()` use the same set of default `navbar_options()`.
 
-   In `navbar_options()`, `inverse` is replaced by `theme`, which takes values `"light"` (dark text on a **light** background), `"dark"` (light text on a **dark** background), or `"auto"` (follow page settings). (#1146)
+   In `navbar_options()`, `inverse` is replaced by `theme`, which takes values `"light"` (dark text on a **light** background), `"dark"` (light text on a **dark** background), or `"auto"` (follow page settings, the default). This change affects that default navbar foreground and background colors for Bootswatch preset themes with Bootstrap 5. Detailed instructions for customizing the navbar appearance, especially for Bootswatch themes, can be found in `?navbar_options`. (#1146)
 
 ## New features
 

--- a/R/navbar_options.R
+++ b/R/navbar_options.R
@@ -58,9 +58,12 @@
 #'
 #' ```r
 #' ui <- page_navbar(
-#'   theme = bs_theme(5, "flatly"),
-#'   navbar_light_bg = "#18BC9C", # flatly's success color (teal)
-#'   navbar_dark_bg = "#2C3E50"   # flatly's primary color (navy)
+#'   theme = bs_theme(
+#'     5,
+#'     preset = "flatly",
+#'     navbar_light_bg = "#18BC9C", # flatly's success color (teal)
+#'     navbar_dark_bg = "#2C3E50"   # flatly's primary color (navy)
+#'   )
 #' )
 #' ```
 #'
@@ -69,8 +72,11 @@
 #'
 #' ```r
 #' ui <- page_navbar(
-#'   theme = bs_theme(5, "flatly"),
-#'   navbar_bg = "#E74C3C" # flatly's danger color (red)
+#'   theme = bs_theme(
+#'     5,
+#'     preset = "flatly",
+#'     navbar_bg = "#E74C3C" # flatly's danger color (red)
+#'   )
 #' )
 #' ```
 #'

--- a/R/navbar_options.R
+++ b/R/navbar_options.R
@@ -5,7 +5,76 @@
 #' This helper should be used to create the list of options expected by
 #' `navbar_options` in [page_navbar()] and [navset_bar()].
 #'
-#' ## Changelog
+#' ## Navbar style with Bootstrap 5 and Bootswatch themes
+#'
+#' In \pkg{bslib} v0.9.0, the default navbar colors for Bootswatch themes with
+#' Bootstrap 5 changed. Prior to v0.9.0, bslib pre-selected navbar background
+#' colors in light and dark mode; after v0.9.0 the default navbar colors are
+#' less opinionated by default and follow light or dark mode (see
+#' [input_dark_mode()]).
+#'
+#' You can use `navbar_options()` to adjust the colors of the navbar when using
+#' a Bootswatch preset theme with Bootstrap 5. For example, the [Bootswatch
+#' documentation for the Flatly theme](https://bootswatch.com/flatly/) shows
+#' 4 navbar variations. Inspecting the source code for the first example reveals
+#' the following markup:
+#'
+#' ```html
+#' <nav class="navbar navbar-expand-lg bg-primary" data-bs-theme="dark">
+#'   <!-- all of the navbar html -->
+#' </nav>
+#' ```
+#'
+#' Note that this navbar uses the `bg-primary` class for a dark navy background.
+#' The navbar's white text is controlled by the `data-bs-theme="dark"`
+#' attribute, which is used by Bootstrap for light text on a _dark_ background.
+#' In \pkg{bslib}, you can achieve this look with:
+#'
+#' ```r
+#' ui <- page_navbar(
+#'   theme = bs_theme(5, "flatly"),
+#'   navbar_options = navbar_options(class = "bg-primary", theme = "dark")
+#' )
+#' ```
+#'
+#' This particular combination of `class = "bg-primary"` and `theme = "dark"`
+#' works well for most Bootswatch presets.
+#'
+#' Another variation from the Flatly documentation features a navar with dark
+#' text on a light background:
+#'
+#' ```r
+#' ui <- page_navbar(
+#'   theme = bs_theme(5, "flatly"),
+#'   navbar_options = navbar_options(class = "bg-light", theme = "light")
+#' )
+#' ```
+#'
+#' The above options set navbar foreground and background colors that are always
+#' the same in both light and dark modes. To customize the navbar colors used in
+#' light or dark mode, you can use the `$navbar-light-bg` and `$navbar-dark-bg`
+#' Sass variables. When provided, bslib will automatically choose to use
+#' light or dark text as the foreground color.
+#'
+#' ```r
+#' ui <- page_navbar(
+#'   theme = bs_theme(5, "flatly"),
+#'   navbar_light_bg = "#18BC9C", # flatly's success color (teal)
+#'   navbar_dark_bg = "#2C3E50"   # flatly's primary color (navy)
+#' )
+#' ```
+#'
+#' Finally, you can also use the `$navbar-bg` Sass variable to set the navbar
+#' background color for both light and dark modes:
+#'
+#' ```r
+#' ui <- page_navbar(
+#'   theme = bs_theme(5, "flatly"),
+#'   navbar_bg = "#E74C3C" # flatly's danger color (red)
+#' )
+#' ```
+#'
+#' @section Changelog:
 #'
 #' This function was introduced in \pkg{bslib} v0.9.0, replacing the `position`,
 #' `bg`, `inverse`, `collapsible` and `underline` arguments of [page_navbar()]

--- a/man/navbar_options.Rd
+++ b/man/navbar_options.Rd
@@ -48,7 +48,72 @@ This helper should be used to create the list of options expected by
 \code{navbar_options} in \code{\link[=page_navbar]{page_navbar()}} and \code{\link[=navset_bar]{navset_bar()}}.
 }
 \details{
-\subsection{Changelog}{
+\subsection{Navbar style with Bootstrap 5 and Bootswatch themes}{
+
+In \pkg{bslib} v0.9.0, the default navbar colors for Bootswatch themes with
+Bootstrap 5 changed. Prior to v0.9.0, bslib pre-selected navbar background
+colors in light and dark mode; after v0.9.0 the default navbar colors are
+less opinionated by default and follow light or dark mode (see
+\code{\link[=input_dark_mode]{input_dark_mode()}}).
+
+You can use \code{navbar_options()} to adjust the colors of the navbar when using
+a Bootswatch preset theme with Bootstrap 5. For example, the \href{https://bootswatch.com/flatly/}{Bootswatch documentation for the Flatly theme} shows
+4 navbar variations. Inspecting the source code for the first example reveals
+the following markup:
+
+\if{html}{\out{<div class="sourceCode html">}}\preformatted{<nav class="navbar navbar-expand-lg bg-primary" data-bs-theme="dark">
+  <!-- all of the navbar html -->
+</nav>
+}\if{html}{\out{</div>}}
+
+Note that this navbar uses the \code{bg-primary} class for a dark navy background.
+The navbar's white text is controlled by the \code{data-bs-theme="dark"}
+attribute, which is used by Bootstrap for light text on a \emph{dark} background.
+In \pkg{bslib}, you can achieve this look with:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{ui <- page_navbar(
+  theme = bs_theme(5, "flatly"),
+  navbar_options = navbar_options(class = "bg-primary", theme = "dark")
+)
+}\if{html}{\out{</div>}}
+
+This particular combination of \code{class = "bg-primary"} and \code{theme = "dark"}
+works well for most Bootswatch presets.
+
+Another variation from the Flatly documentation features a navar with dark
+text on a light background:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{ui <- page_navbar(
+  theme = bs_theme(5, "flatly"),
+  navbar_options = navbar_options(class = "bg-light", theme = "light")
+)
+}\if{html}{\out{</div>}}
+
+The above options set navbar foreground and background colors that are always
+the same in both light and dark modes. To customize the navbar colors used in
+light or dark mode, you can use the \verb{$navbar-light-bg} and \verb{$navbar-dark-bg}
+Sass variables. When provided, bslib will automatically choose to use
+light or dark text as the foreground color.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{ui <- page_navbar(
+  theme = bs_theme(5, "flatly"),
+  navbar_light_bg = "#18BC9C", # flatly's success color (teal)
+  navbar_dark_bg = "#2C3E50"   # flatly's primary color (navy)
+)
+}\if{html}{\out{</div>}}
+
+Finally, you can also use the \verb{$navbar-bg} Sass variable to set the navbar
+background color for both light and dark modes:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{ui <- page_navbar(
+  theme = bs_theme(5, "flatly"),
+  navbar_bg = "#E74C3C" # flatly's danger color (red)
+)
+}\if{html}{\out{</div>}}
+}
+}
+\section{Changelog}{
+
 
 This function was introduced in \pkg{bslib} v0.9.0, replacing the \code{position},
 \code{bg}, \code{inverse}, \code{collapsible} and \code{underline} arguments of \code{\link[=page_navbar]{page_navbar()}}
@@ -57,7 +122,7 @@ removed in a future version of \pkg{bslib}. Note that the deprecated
 \code{inverse} argument of \code{\link[=page_navbar]{page_navbar()}} and \code{\link[=navset_bar]{navset_bar()}} was replaced with
 the \code{theme} argument of \code{navbar_options()}.
 }
-}
+
 \examples{
 navbar_options(position = "static-top", bg = "#2e9f7d", underline = FALSE)
 

--- a/man/navbar_options.Rd
+++ b/man/navbar_options.Rd
@@ -96,9 +96,12 @@ Sass variables. When provided, bslib will automatically choose to use
 light or dark text as the foreground color.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{ui <- page_navbar(
-  theme = bs_theme(5, "flatly"),
-  navbar_light_bg = "#18BC9C", # flatly's success color (teal)
-  navbar_dark_bg = "#2C3E50"   # flatly's primary color (navy)
+  theme = bs_theme(
+    5,
+    preset = "flatly",
+    navbar_light_bg = "#18BC9C", # flatly's success color (teal)
+    navbar_dark_bg = "#2C3E50"   # flatly's primary color (navy)
+  )
 )
 }\if{html}{\out{</div>}}
 
@@ -106,8 +109,11 @@ Finally, you can also use the \verb{$navbar-bg} Sass variable to set the navbar
 background color for both light and dark modes:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{ui <- page_navbar(
-  theme = bs_theme(5, "flatly"),
-  navbar_bg = "#E74C3C" # flatly's danger color (red)
+  theme = bs_theme(
+    5,
+    preset = "flatly",
+    navbar_bg = "#E74C3C" # flatly's danger color (red)
+  )
 )
 }\if{html}{\out{</div>}}
 }


### PR DESCRIPTION
In setting up https://github.com/rstudio/shinycoreci/pull/283 – where we'll have test coverage for the default `page_navbar()` appearance with all Bootswatch themes – I realized that we need better instructions specifically for anyone using BS5 with a Bootswatch preset.

I added a new section to `?navbar_options` that walks through the process for getting the same navbar appearance as can be found in the Bootswatch docs for a theme. I also touched on the Sass variables we introduce.

https://github.com/rstudio/shinycoreci/pull/283 reveals that the changes in the default appearance are sub-optimal, but open the door for better customization that more closely follows upstream best practices – i.e. you could follow the Bootswatch or Bootstrap docs because they easily translate to `navbar_options()`.

I've considered a few other options for improving the default experience, but it's difficult to do without adding more undesirable complexity.