### PR TITLE
Add 'copy.mode = FALSE' to all calls of file.copy outside tools directory

### DIFF
--- a/R/bs-dependencies.R
+++ b/R/bs-dependencies.R
@@ -85,7 +85,7 @@ bs_theme_dependencies <- function(
         dir.create(out_dir)
       }
       out_file <- file.path(out_dir, basename(precompiled_css))
-      file.copy(precompiled_css, out_file)
+      file.copy(precompiled_css, out_file, copy.mode = FALSE)
 
       # Usually sass() would handle file_attachments and dependencies,
       # but we need to do this manually
@@ -130,7 +130,8 @@ bs_theme_dependencies <- function(
   success_js_files <- file.copy(
     c(js_files, js_map_files),
     out_file_dir,
-    overwrite = TRUE
+    overwrite = TRUE,
+    copy.mode = FALSE
   )
   if (any(!success_js_files)) {
     warning(
@@ -248,7 +249,7 @@ bs_dependency <- function(
         basename(outfile)
       )
     }
-    success <- file.copy(script, dirname(outfile), overwrite = TRUE)
+    success <- file.copy(script, dirname(outfile), overwrite = TRUE, copy.mode = FALSE)
     if (!all(success)) {
       stop(
         "Failed to copy the following script(s): ",


### PR DESCRIPTION
Fix for https://github.com/rstudio/bslib/issues/1154.

I am facing the same problem and I saw that the issue was reported earlier.

## Pull Request

Before you submit a pull request, please ensure you've completed the following checklist

- [x] Ensure there is an already open and relevant [GitHub issue](https://github.com/rstudio/bslib/issues/new) describing the problem in detail and you've already received some indication from the maintainers that they are welcome to a contribution to fix the problem. This helps us to prevent wasting anyone's time. 

- [ ] Add unit tests in the tests/testthat directory.

- [ ] This project uses [roxygen2 for documentation](http://r-pkgs.had.co.nz/man.html). If you've made changes to documentation, run `devtools::document()`.

- [ ] Run `devtools::check()` (or, equivalently, click on Build->Check Package in the RStudio IDE) to make sure your change did not add any messages, warnings, or errors.
    * Note there is a decent chance that some tests were already failing before your changes. Just make sure you haven't introduced any new ones.
    
- [ ] Ensure your code changes follow the style outlined in http://r-pkgs.had.co.nz/style.html

- [ ] Add an entry to NEWS.md concisely describing what you changed.
