### PR TITLE
feat(page_main_container): Remove fill container and min-height/width when `fillable=FALSE`

### DIFF
--- a/R/navs-legacy.R
+++ b/R/navs-legacy.R
@@ -409,7 +409,7 @@ navbarPage_ <- function(
         fillable = !isFALSE(fillable),
         border_radius = FALSE,
         border = !fluid,
-        page_main_container(contents)
+        page_main_container(contents, fillable = !isFALSE(fillable))
       )
     )
 

--- a/R/page.R
+++ b/R/page.R
@@ -281,7 +281,7 @@ page_sidebar <- function(
     border = FALSE,
     border_radius = FALSE,
     !!!dots$attribs,
-    page_main_container(dots$children)
+    page_main_container(dots$children, fillable = fillable)
   )
 
   page_fillable(
@@ -297,12 +297,14 @@ page_sidebar <- function(
   )
 }
 
-page_main_container <- function(...) {
-  as_fill_carrier(
+page_main_container <- function(..., fillable = TRUE) {
+  htmltools::bindFillRole(
     tags$main(
       class = "bslib-page-main bslib-gap-spacing",
       ...
-    )
+    ),
+    item = TRUE,
+    container = fillable
   )
 }
 
@@ -414,7 +416,7 @@ page_navbar <- function(
   # TODO: Coordinate with next bslib version bump in Shiny to use the new interface
   was_called_by_shiny <-
     isNamespaceLoaded("shiny") &&
-      identical(rlang::caller_fn(), shiny::navbarPage)
+    identical(rlang::caller_fn(), shiny::navbarPage)
 
   .navbar_options <- navbar_options_resolve_deprecated(
     options_user = navbar_options,

--- a/inst/components/scss/page_sidebar.scss
+++ b/inst/components/scss/page_sidebar.scss
@@ -44,7 +44,7 @@ $bslib-sidebar-padding: $spacer * 1.5 !default;
   // Ensure the page-level main area has a minimum height and width to prevent
   // overly squished content in small screens, like IDE preview panels.
   .bslib-sidebar-layout {
-    .bslib-page-main {
+    .bslib-page-main.html-fill-container {
       min-height: var(--bslib-page-main-min-height, #{$bslib-page-main-min-height});
     }
 
@@ -52,7 +52,7 @@ $bslib-sidebar-padding: $spacer * 1.5 !default;
     // not collapsed or in transition) to prevent overlap with toggle button.
     &:not(.sidebar-collapsed),
     &.transitioning {
-      .bslib-page-main {
+      .bslib-page-main.html-fill-container {
         min-width: var(--bslib-page-main-min-width, #{$bslib-page-main-min-width});
       }
     }


### PR DESCRIPTION
* `page_main_container()` is only a fill carrier when `fillable = TRUE`. Or more specifically, it should only be a fill container when `fillable` is `TRUE`.
* Only apply min-height/width when the main container is fillable.