### PR TITLE
docs: Replaced "it's" denoting possesion to "its"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Fixed an issue where the `<main>` areas of `page_sidebar()` and `page_navbar()` (with a `sidebar`) were made to be a fillable containers even when `fillable = FALSE`. (#1188)
 
+* Fixed some typos in the documentation
+
 # bslib 0.9.0
 
 ## Breaking changes

--- a/R/bs-theme-layers.R
+++ b/R/bs-theme-layers.R
@@ -128,7 +128,7 @@ ensure_default_flag <- function(x) {
             "Ignoring `bs_add_variables()`'s `.default_flag = TRUE` for ",
             "the ",
             nm,
-            " variable (since it has it's own `default_flag`)."
+            " variable (since it has its own `default_flag`)."
           )
         }
         return(val)

--- a/R/bs-theme-preview.R
+++ b/R/bs-theme-preview.R
@@ -235,7 +235,7 @@ bs_themer_ui <- function(opts, vals, theme) {
         class = "card shadow",
         style = css(
           # The bootstrap-colorpicker plugin sets a z-index of 1060 on
-          # it's inputs, so the container needs a smaller index, than that
+          # its inputs, so the container needs a smaller index, than that
           # https://github.com/rstudio/bslib/blob/e4da71f3/inst/lib/bs-colorpicker/css/bootstrap-colorpicker.css#L38
           #
           # It's also important that this z-index is higher than 1030 so it's

--- a/R/files.R
+++ b/R/files.R
@@ -51,7 +51,7 @@ bootswatch_sass_file <- function(theme, file, version = version_default()) {
 }
 
 # Given a vector of sass_file()s, create a list of sass_bundles(),
-# so each rule may be removed layer (by it's files basename)
+# so each rule may be removed layer (by its files basename)
 rule_bundles <- function(files) {
   files <- lapply(files, as_sass_file)
   paths <- vapply(files, get_sass_file_path, character(1))

--- a/R/layout.R
+++ b/R/layout.R
@@ -198,7 +198,7 @@ is_probably_a_css_unit <- function(x) {
 #'     where each value represents the height of the relevant row. If more rows
 #'     are needed than values provided, the pattern will repeat. For example,
 #'     `row_heights = list("auto", 1)` allows the height of odd rows to be
-#'     driven my it's contents and even rows to be
+#'     driven by its contents and even rows to be
 #'     [`1fr`](https://css-tricks.com/introduction-fr-css-unit/).
 #'   * A character vector/string of [CSS length units][htmltools::validateCssUnit()].
 #'     In this case, the value is supplied directly to `grid-auto-rows`.

--- a/man/layout_columns.Rd
+++ b/man/layout_columns.Rd
@@ -48,7 +48,7 @@ allows even rows to take up twice as much space as odd rows.
 where each value represents the height of the relevant row. If more rows
 are needed than values provided, the pattern will repeat. For example,
 \code{row_heights = list("auto", 1)} allows the height of odd rows to be
-driven my it's contents and even rows to be
+driven by its contents and even rows to be
 \href{https://css-tricks.com/introduction-fr-css-unit/}{\verb{1fr}}.
 \item A character vector/string of \link[htmltools:validateCssUnit]{CSS length units}.
 In this case, the value is supplied directly to \code{grid-auto-rows}.

--- a/vignettes/any-project/index.Rmd
+++ b/vignettes/any-project/index.Rmd
@@ -105,7 +105,7 @@ page_fillable(
 Use the `theme` parameter of a compatible output format[^output-format] to get started in R Markdown.
 By supplying `bslib: true` to that parameter, you'll get the latest "stock" version of Bootstrap (akin to using `page_*()` in Shiny). Alternatively, you can supply `bs_theme()` parameters to the `theme` parameter to specify the Bootstrap version, add a Bootswatch theme, and customize theming colors ([Getting Started with Theming](../theming) covers this in more depth).
 
-[^output-format]: In theory, any format that passes it's `theme` parameter to `rmarkdown::html_document_base()` is compatible with `bslib`.
+[^output-format]: In theory, any format that passes its `theme` parameter to `rmarkdown::html_document_base()` is compatible with `bslib`.
 However, in practice, the format may not be compatible with modern versions of Bootstrap.
 
 
@@ -151,7 +151,7 @@ In addition to `rmarkdown::html_document`, there are at least a few other R Mark
 
 ## In production
 
-Before deploying any `{bslib}` project to production, it's wise to "hard-code" the version of Bootstrap used when it was developed. This reduces the chance of the project breaking if and when `{bslib}` updates it's Bootstrap dependency. To do so, call `version_default()` to get the current version of Bootstrap, then pass that value to relevant `theme` object.
+Before deploying any `{bslib}` project to production, it's wise to "hard-code" the version of Bootstrap used when it was developed. This reduces the chance of the project breaking if and when `{bslib}` updates its Bootstrap dependency. To do so, call `version_default()` to get the current version of Bootstrap, then pass that value to relevant `theme` object.
 
 
 ::: usage

--- a/vignettes/dashboards/index.Rmd
+++ b/vignettes/dashboards/index.Rmd
@@ -459,7 +459,7 @@ shinyApp(ui, server)
 
 ## In production
 
-Before deploying a dashboard to production, it's wise to "hard-code" the version of Bootstrap used when it was developed. This reduces the chance of the dashboard breaking if and when `bslib` updates it's Bootstrap dependency. To do so, call `version_default()` to get the current version of Bootstrap, then pass that value to `bs_theme(version = ...)` (and pass that theme object to the `theme` argument of the relevant `page_*()` function).
+Before deploying a dashboard to production, it's wise to "hard-code" the version of Bootstrap used when it was developed. This reduces the chance of the dashboard breaking if and when `bslib` updates its Bootstrap dependency. To do so, call `version_default()` to get the current version of Bootstrap, then pass that value to `bs_theme(version = ...)` (and pass that theme object to the `theme` argument of the relevant `page_*()` function).
 
 ```r
 library(shiny)

--- a/vignettes/filling/index.Rmd
+++ b/vignettes/filling/index.Rmd
@@ -25,7 +25,7 @@ This article covers the building blocks of filling layouts in `bslib`: **fillabl
 
 Since, in theory, essentially any UI element can be coerced into a **fillable container** and/or **fill item**[^flexbox], it's useful to first study their behavior in the abstract, which we do next in the [In theory](#in-theory) section. After, the [In practice](#in-practice) section reinforces those concepts and demonstrates their power with practical examples.
 
-[^flexbox]: Technically speaking, a **fillable container** is just a [CSS flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) container with `flex-direction: column` (which makes it's children flex items). And, when a **fill item** appears as a direct child of a **fillable container**, it is given a `flex` property of `1` (i.e., it's allowed to grow/shrink).
+[^flexbox]: Technically speaking, a **fillable container** is just a [CSS flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) container with `flex-direction: column` (which makes its children flex items). And, when a **fill item** appears as a direct child of a **fillable container**, it is given a `flex` property of `1` (i.e., it's allowed to grow/shrink).
 
 Throughout these sections, be aware that most `bslib` components, as well as many Shiny outputs (e.g., `plotOutput()`, `plotlyOutput()`, etc) classify as [fill items]{.b-blue} by default. This means they possess the potential to grow/shrink to fit their container, but that potential is only activated when their _immediate parent_ is a [fillable container]{.b-pink} _with a defined height_. Also be aware that `bslib` components and many Shiny outputs have `fill` and/or `fillable` arguments to opt out/in of this behavior (and `bslib` also provides an API for testing/coercing these properties on _any_ UI element -- see `is_fill()` for more).
 
@@ -146,7 +146,7 @@ child <- function(..., fill = TRUE, fillable = FALSE, tooltip = NULL, placement 
 
 ::: row
 ::: col-md-6
-Just like any other HTML **container**, a [fillable container]{.b-pink}'s default height depends on the height of it's children. So, for example, if there's a single [fill item]{.b-blue} with a defined height of `400px` (the default for most Shiny outputs), the [fillable container]{.b-pink}'s height is also `400px` (plus any padding, border, etc).
+Just like any other HTML **container**, a [fillable container]{.b-pink}'s default height depends on the height of its children. So, for example, if there's a single [fill item]{.b-blue} with a defined height of `400px` (the default for most Shiny outputs), the [fillable container]{.b-pink}'s height is also `400px` (plus any padding, border, etc).
 :::
 
 ::: col-md-6
@@ -320,7 +320,7 @@ fillable_container(
 
 ::: {.row .mt-3}
 ::: col-md-6
-You might wonder, why then would we want or need `fillable = FALSE` or `fill = FALSE` on a `card_body()`? One big reason is that [fillable containers]{.b-pink} are powered by [CSS flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/), which changes the way it's children are rendered. And, although those changes are nice for "stretchy" children, there are [downsides for rendering inline elements](../cards#flexbox). So, that's why, it's recommended that you use [multiple card bodies](../cards#multiple-card_body) when combining [fill]{.b-blue} with [non-fill]{.b-orange}
+You might wonder, why then would we want or need `fillable = FALSE` or `fill = FALSE` on a `card_body()`? One big reason is that [fillable containers]{.b-pink} are powered by [CSS flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/), which changes the way its children are rendered. And, although those changes are nice for "stretchy" children, there are [downsides for rendering inline elements](../cards#flexbox). So, that's why, it's recommended that you use [multiple card bodies](../cards#multiple-card_body) when combining [fill]{.b-blue} with [non-fill]{.b-orange}
 :::
 
 ::: col-md-6
@@ -385,7 +385,7 @@ plots <- lapply(plots, function(x) {
 
 ### Filling the window
 
-Perhaps the most important [fillable container]{.b-pink} is `page_fillable()`, which sets it's height equal to the browser window. Thus, if [fill items]{.b-blue} appear as direct children, they'll fill the window. `page_fillable()` also defaults to `fillable_mobile = FALSE`, which means the height isn't set equal to the viewport on mobile. As a result, fill items use their own defined height (instead of the viewport size) on mobile, which is often better behavior when showing multiple outputs.
+Perhaps the most important [fillable container]{.b-pink} is `page_fillable()`, which sets its height equal to the browser window. Thus, if [fill items]{.b-blue} appear as direct children, they'll fill the window. `page_fillable()` also defaults to `fillable_mobile = FALSE`, which means the height isn't set equal to the viewport on mobile. As a result, fill items use their own defined height (instead of the viewport size) on mobile, which is often better behavior when showing multiple outputs.
 
 
 ```{r page-fillable, as_iframe=TRUE, resizable=TRUE}
@@ -488,7 +488,7 @@ page_fillable(
 )
 ```
 
-Note that, if we changed `page_fillable()` to `page_fluid()` (or `page_fixed()`), each plot would render to it's default height (`400px`) since we no longer have a [fillable]{.b-pink} with a specified height. That said, even in that case, if we expand the card to full-screen, the plot still grows to fit the full screen card (since the `card()` is then a [fillable]{.b-pink} container with a specified height, the `card_body()` is a [fill carrier]{.b-purple}, and the plot is a [fill item]{.b-blue}).
+Note that, if we changed `page_fillable()` to `page_fluid()` (or `page_fixed()`), each plot would render to its default height (`400px`) since we no longer have a [fillable]{.b-pink} with a specified height. That said, even in that case, if we expand the card to full-screen, the plot still grows to fit the full screen card (since the `card()` is then a [fillable]{.b-pink} container with a specified height, the `card_body()` is a [fill carrier]{.b-purple}, and the plot is a [fill item]{.b-blue}).
 
 
 ### Sidebar layouts
@@ -560,7 +560,7 @@ shinyApp(ui, server)
 :::: {.row .mt-3}
 
 ::: col-md-6
-`{DT}`'s `datatable()` has it's own unique interface for filling a container. Specifically, make sure to set `datatable(fillContainer = TRUE)` in order for the table to grow/shrink as you'd expect it to.
+`{DT}`'s `datatable()` has its own unique interface for filling a container. Specifically, make sure to set `datatable(fillContainer = TRUE)` in order for the table to grow/shrink as you'd expect it to.
 :::
 
 ::: col-md-6

--- a/vignettes/sidebars/index.Rmd
+++ b/vignettes/sidebars/index.Rmd
@@ -386,7 +386,7 @@ Just like `page_navbar()`, `navset_card_tab()` also has a `sidebar` argument tha
 
 ### Restricting growth
 
-Just like with [cards](../cards#restricting-growth), when a [filling layout](#hello-sidebar) isn't enforcing the size of the `layout_sidebar()`, it will allow it's contents to decide how big it should be. Thus, if there a large amount of sidebar/main contents, consider specifying a `height` or `max_height` via `card()` (as well as `full_screen = TRUE` to reduce the need for scrolling).
+Just like with [cards](../cards#restricting-growth), when a [filling layout](#hello-sidebar) isn't enforcing the size of the `layout_sidebar()`, it will allow its contents to decide how big it should be. Thus, if there a large amount of sidebar/main contents, consider specifying a `height` or `max_height` via `card()` (as well as `full_screen = TRUE` to reduce the need for scrolling).
 
 ```{r restricting-growth, as_iframe = TRUE, resizable = TRUE}
 page_fixed(
@@ -410,7 +410,7 @@ Although sidebars work just fine outside Shiny, using them in Shiny provides a f
 
 ### Conditional contents
 
-Sometimes in a multiple page/tab setting, it's useful to have a sidebar on every page/tab, but changes it's contents based on which page/tab is active.[^4] Thanks to `conditionalPanel()`, this can be done fairly easily in a Shiny app with `page_navbar()` (or in `navset_card_tab()`/`navset_tab_pill()`). The trick is to provide an `id` to the `page_navbar()` and then reference that `id` in the `conditionalPanel()`:
+Sometimes in a multiple page/tab setting, it's useful to have a sidebar on every page/tab, but changes its contents based on which page/tab is active.[^4] Thanks to `conditionalPanel()`, this can be done fairly easily in a Shiny app with `page_navbar()` (or in `navset_card_tab()`/`navset_tab_pill()`). The trick is to provide an `id` to the `page_navbar()` and then reference that `id` in the `conditionalPanel()`:
 
 [^4]: If the controls depend on some other application state, you'll need to use `uiOutput()` to fill the contents of a `sidebar()`).
 
@@ -608,7 +608,7 @@ Both functions also include a `class` argument that works well with [Bootstrap u
 
 Be aware that in `layout_sidebar()`, `bg`, `class` and `style` attributes are applied to the main content area's container and _not_ the overall layout container.
 To add additional classes to the layout container, use `htmltools::tagAppendAttributes()`.
-Also note that `layout_sidebar()` derives some of it's default style from Bootstrap CSS variables (e.g., `--bs-card-border-color`), which enables theming at the component-level ([theming via `bs_theme()`](../bs5-variables) works on the page-level).
+Also note that `layout_sidebar()` derives some of its default style from Bootstrap CSS variables (e.g., `--bs-card-border-color`), which enables theming at the component-level ([theming via `bs_theme()`](../bs5-variables) works on the page-level).
 
 The following example combines all of these concepts to create sidebar with a dark background.
 Utility classes are used to make the sidebar text monospace and bold, and we used `tagAppendAttributes()` to tweak the border color of the sidebar layout to match the sidebar background.

--- a/vignettes/theming/index.Rmd
+++ b/vignettes/theming/index.Rmd
@@ -31,7 +31,7 @@ This article provides a general overview of theming techniques available in `{bs
 
 ## Real-time theming {#real-time}
 
-To get started theming, consider overlaying a real-time theming widget on your Shiny app (or `runtime: shiny` R Markdown document). This is a great way to experiment with different [Bootswatch](#bootswatch) themes, [main colors](#main-colors), fonts, and more. To add the widget, call `bs_themer()` in a Shiny runtime content (i.e., within the `server` function) and also make sure the app/document [uses `{bslib}` for it's Bootstrap dependency](../any-project).
+To get started theming, consider overlaying a real-time theming widget on your Shiny app (or `runtime: shiny` R Markdown document). This is a great way to experiment with different [Bootswatch](#bootswatch) themes, [main colors](#main-colors), fonts, and more. To add the widget, call `bs_themer()` in a Shiny runtime content (i.e., within the `server` function) and also make sure the app/document [uses `{bslib}` for its Bootstrap dependency](../any-project).
 
 <div class="usage">
 ```r
@@ -177,7 +177,7 @@ When choosing fonts, keep in mind that it's generally good practice to put serif
 
 ## Theming variables
 
-`bs_theme()` also provides access to 100s of more specific [theming options](../bs5-variables) by considering anything passed through it's `...` argument to be a new [Bootstrap Sass variable defaults](https://getbootstrap.com/docs/5.0/customize/sass/#variable-defaults). This allows you to get more targetted with your theming; for example, let's set the [`$progress-bar-bg`](../bs5-variables#progress-bar-bg) Sass variable to `'orange'` (a CSS color).
+`bs_theme()` also provides access to 100s of more specific [theming options](../bs5-variables) by considering anything passed through its `...` argument to be a new [Bootstrap Sass variable defaults](https://getbootstrap.com/docs/5.0/customize/sass/#variable-defaults). This allows you to get more targetted with your theming; for example, let's set the [`$progress-bar-bg`](../bs5-variables#progress-bar-bg) Sass variable to `'orange'` (a CSS color).
 
 <div class="usage">
 ```r

--- a/vignettes/value-boxes/index.Rmd
+++ b/vignettes/value-boxes/index.Rmd
@@ -198,7 +198,7 @@ Under-the-hood, `value_box()` is implemented using `card()`, mainly to inherit i
 
 Note that, since this example is statically rendered (outside of Shiny), we make use of `htmlwidgets::onRender()` to add some JavaScript that effectively says: "Show the xaxis of the chart when it's taller than 200 pixels; otherwise, hide it".
 
-Those of you who aren't wanting to write JavaScript can achieve similar behavior (i.e., displaying a different chart depending on it's size) via `shiny::getCurrentOutputInfo()`, as mentioned in the [article on cards](../cards#shiny). In fact, here's the [source code](https://github.com/rstudio/bslib/tree/main/inst/examples-shiny/value_box) for a Shiny app does effectively the same thing without any JavaScript (note how it also leverages other `getCurrentOutputInfo()` values to avoid hard coding `"white"` into the colors of the sparklines).
+Those of you who aren't wanting to write JavaScript can achieve similar behavior (i.e., displaying a different chart depending on its size) via `shiny::getCurrentOutputInfo()`, as mentioned in the [article on cards](../cards#shiny). In fact, here's the [source code](https://github.com/rstudio/bslib/tree/main/inst/examples-shiny/value_box) for a Shiny app does effectively the same thing without any JavaScript (note how it also leverages other `getCurrentOutputInfo()` values to avoid hard coding `"white"` into the colors of the sparklines).
 :::
 
 ::: col-md-6


### PR DESCRIPTION
I know this is pedantic but these redundant apostrophes were quite glaring when reading the documentation.

## Pull Request

Before you submit a pull request, please ensure you've completed the following checklist

- [ ] Ensure there is an already open and relevant [GitHub issue](https://github.com/rstudio/bslib/issues/new) describing the problem in detail and you've already received some indication from the maintainers that they are welcome to a contribution to fix the problem. This helps us to prevent wasting anyone's time. 

NA as this PR doesn't add modify any code, just documentation.

- [ ] Add unit tests in the tests/testthat directory.

NA as this PR doesn't add modify any code, just documentation.

- [x] This project uses [roxygen2 for documentation](http://r-pkgs.had.co.nz/man.html). If you've made changes to documentation, run `devtools::document()`.

Updated documentation has been generated.

- [x] Run `devtools::check()` (or, equivalently, click on Build->Check Package in the RStudio IDE) to make sure your change did not add any messages, warnings, or errors.
    * Note there is a decent chance that some tests were already failing before your changes. Just make sure you haven't introduced any new ones.

Ran with 0 errors, 0 warnings, and 2 notes:

```
Duration: 1m 58.6s

❯ checking installed package size ... NOTE
    installed size is 11.7Mb
    sub-directories of 1Mb or more:
      components   1.0Mb
      fonts        2.4Mb
      lib          5.3Mb

❯ checking for future file timestamps ... NOTE
  unable to verify current time

0 errors ✔ | 0 warnings ✔ | 2 notes ✖
```
    
- [ ] Ensure your code changes follow the style outlined in http://r-pkgs.had.co.nz/style.html

NA as this PR doesn't add modify any code, just documentation.

- [x] Add an entry to NEWS.md concisely describing what you changed.
