### PR TITLE
chore: regenerate docs with roxygen2 8.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,7 +75,6 @@ Config/testthat/start-first: zzzz-bs-sass, fonts, zzz-precompile, theme-*,
     rmd-*
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Collate:
     'accordion.R'
     'breakpoints.R'
@@ -126,3 +125,4 @@ Collate:
     'value-box.R'
     'version-default.R'
     'versions.R'
+Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,6 +69,7 @@ Config/Needs/routine: chromote, desc, renv
 Config/Needs/website: brio, crosstalk, dplyr, DT, ggplot2, glue,
     htmlwidgets, leaflet, lorem, palmerpenguins, plotly, purrr, rprojroot,
     rstudio/htmltools, scales, stringr, tidyr, webshot2
+Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Config/testthat/start-first: zzzz-bs-sass, fonts, zzz-precompile, theme-*,
@@ -125,4 +126,3 @@ Collate:
     'value-box.R'
     'version-default.R'
     'versions.R'
-Config/roxygen2/version: 8.0.0

--- a/man/accordion.Rd
+++ b/man/accordion.Rd
@@ -41,7 +41,7 @@ when \code{multiple=TRUE}.}
 
 \item{value}{A character string that uniquely identifies this panel.}
 
-\item{icon}{A \link[htmltools:builder]{htmltools::tag} child (e.g., \code{\link[bsicons:bs_icon]{bsicons::bs_icon()}}) which is positioned just before the \code{title}.}
+\item{icon}{A \link[htmltools:tag]{htmltools::tag} child (e.g., \code{\link[bsicons:bs_icon]{bsicons::bs_icon()}}) which is positioned just before the \code{title}.}
 }
 \description{
 An accordion can be used to organize UI elements and content in a limited
@@ -99,10 +99,10 @@ accordion panel.
 \code{\link[=accordion_panel_update]{accordion_panel_update()}} add or remove accordion panels from an
 accordion.
 
-Other Components: 
-\code{\link{card}()},
-\code{\link{popover}()},
-\code{\link{tooltip}()},
-\code{\link{value_box}()}
+Other Components:
+\code{\link[=card]{card()}},
+\code{\link[=popover]{popover()}},
+\code{\link[=tooltip]{tooltip()}},
+\code{\link[=value_box]{value_box()}}
 }
 \concept{Components}

--- a/man/accordion_panel_set.Rd
+++ b/man/accordion_panel_set.Rd
@@ -59,7 +59,7 @@ panel and \code{"before"} will prepend before the first panel.}
 
 \item{value}{A character string that uniquely identifies this panel.}
 
-\item{icon}{A \link[htmltools:builder]{htmltools::tag} child (e.g., \code{\link[bsicons:bs_icon]{bsicons::bs_icon()}}) which is positioned just before the \code{title}.}
+\item{icon}{A \link[htmltools:tag]{htmltools::tag} child (e.g., \code{\link[bsicons:bs_icon]{bsicons::bs_icon()}}) which is positioned just before the \code{title}.}
 }
 \description{
 Dynamically update/modify \code{\link[=accordion]{accordion()}}s in a Shiny app. To be updated

--- a/man/as_fill_carrier.Rd
+++ b/man/as_fill_carrier.Rd
@@ -51,7 +51,7 @@ is_fillable_container(x)
 is_fill_item(x)
 }
 \arguments{
-\item{x}{An \code{\link[htmltools:builder]{htmltools::tag()}}.}
+\item{x}{An \code{\link[htmltools:tag]{htmltools::tag()}}.}
 
 \item{...}{Currently ignored.}
 
@@ -84,7 +84,7 @@ and fill items (fill carriers are both fillable and fill). This is why most
 bslib components (e.g., \code{\link[=card]{card()}}, \code{\link[=card_body]{card_body()}}, \code{\link[=layout_sidebar]{layout_sidebar()}}) possess
 both \code{fillable} and \code{fill} arguments (to control their fill behavior).
 However, sometimes it's useful to add, remove, and/or test fillable/fill
-properties on arbitrary \code{\link[htmltools:builder]{htmltools::tag()}}, which these functions are
+properties on arbitrary \code{\link[htmltools:tag]{htmltools::tag()}}, which these functions are
 designed to do.
 }
 \details{

--- a/man/bootswatch_themes.Rd
+++ b/man/bootswatch_themes.Rd
@@ -18,11 +18,11 @@ Returns a character vector of Bootswatch themes.
 Obtain a list of all available bootswatch themes.
 }
 \seealso{
-Other Bootstrap theme utility functions: 
-\code{\link{bs_get_variables}()},
-\code{\link{builtin_themes}()},
-\code{\link{theme_bootswatch}()},
-\code{\link{theme_version}()},
-\code{\link{versions}()}
+Other Bootstrap theme utility functions:
+\code{\link[=bs_get_variables]{bs_get_variables()}},
+\code{\link[=builtin_themes]{builtin_themes()}},
+\code{\link[=theme_bootswatch]{theme_bootswatch()}},
+\code{\link[=theme_version]{theme_version()}},
+\code{\link[=versions]{versions()}}
 }
 \concept{Bootstrap theme utility functions}

--- a/man/bs_bundle.Rd
+++ b/man/bs_bundle.Rd
@@ -30,7 +30,7 @@ bs_bundle(theme, ...)
 \item \code{bs_add_variables()}: Should be named Sass variables or values that can be
 passed in directly to the \code{defaults} argument of a \code{\link[sass:sass_layer]{sass::sass_layer()}}.
 \item \code{bs_bundle()}: Should be arguments that can be handled by
-\code{\link[sass:sass_layer]{sass::sass_bundle()}} to be appended to the \code{theme}
+\code{\link[sass:sass_bundle]{sass::sass_bundle()}} to be appended to the \code{theme}
 }}
 
 \item{.where}{Whether to place the variable definitions before other Sass
@@ -41,12 +41,12 @@ passed in directly to the \code{defaults} argument of a \code{\link[sass:sass_la
 variable expressions. It's recommended to keep this as \code{TRUE} when \code{.where = "defaults"}.}
 
 \item{rules}{Sass rules. Anything understood by \code{\link[sass:as_sass]{sass::as_sass()}} may be
-provided (e.g., a list, character vector, \code{\link[sass:sass_import]{sass::sass_file()}}, etc)}
+provided (e.g., a list, character vector, \code{\link[sass:sass_file]{sass::sass_file()}}, etc)}
 
-\item{functions}{A character vector or \code{\link[sass:sass_import]{sass::sass_file()}} containing
+\item{functions}{A character vector or \code{\link[sass:sass_file]{sass::sass_file()}} containing
 functions definitions.}
 
-\item{mixins}{A character vector or \code{\link[sass:sass_import]{sass::sass_file()}} containing
+\item{mixins}{A character vector or \code{\link[sass:sass_file]{sass::sass_file()}} containing
 mixin definitions.}
 }
 \value{
@@ -75,7 +75,7 @@ versions.
 
 \item \code{bs_add_mixins()}: Add additional \href{https://rstudio.github.io/sass/articles/sass.html#mixins}{Sass mixins}.
 
-\item \code{bs_bundle()}: Add additional \code{\link[sass:sass_layer]{sass::sass_bundle()}} objects to an
+\item \code{bs_bundle()}: Add additional \code{\link[sass:sass_bundle]{sass::sass_bundle()}} objects to an
 existing \code{theme}.
 
 }}
@@ -142,13 +142,13 @@ on the \pkg{sass} website.
 \code{\link[=bs_theme]{bs_theme()}} creates a Bootstrap theme object, and is the best place
 to start learning about bslib's theming capabilities.
 
-Other Bootstrap theme functions: 
-\code{\link{bs_current_theme}()},
-\code{\link{bs_dependency}()},
-\code{\link{bs_global_theme}()},
-\code{\link{bs_remove}()},
-\code{\link{bs_theme}()},
-\code{\link{bs_theme_dependencies}()},
-\code{\link{bs_theme_preview}()}
+Other Bootstrap theme functions:
+\code{\link[=bs_current_theme]{bs_current_theme()}},
+\code{\link[=bs_dependency]{bs_dependency()}},
+\code{\link[=bs_global_theme]{bs_global_theme()}},
+\code{\link[=bs_remove]{bs_remove()}},
+\code{\link[=bs_theme]{bs_theme()}},
+\code{\link[=bs_theme_dependencies]{bs_theme_dependencies()}},
+\code{\link[=bs_theme_preview]{bs_theme_preview()}}
 }
 \concept{Bootstrap theme functions}

--- a/man/bs_current_theme.Rd
+++ b/man/bs_current_theme.Rd
@@ -22,7 +22,7 @@ This function should generally only be called at print/render time. For
 example:
 \itemize{
 \item Inside the \code{preRenderHook} of \code{htmlwidgets::createWidget()}.
-\item Inside of a custom \link{print} method that generates \link[htmltools:builder]{htmltools::tags}.
+\item Inside of a custom \link{print} method that generates \link[htmltools:tags]{htmltools::tags}.
 \item Inside of a \code{\link[htmltools:tagFunction]{htmltools::tagFunction()}}
 }
 
@@ -39,13 +39,13 @@ possibly other static rendering contexts.
 }
 }
 \seealso{
-Other Bootstrap theme functions: 
-\code{\link{bs_add_variables}()},
-\code{\link{bs_dependency}()},
-\code{\link{bs_global_theme}()},
-\code{\link{bs_remove}()},
-\code{\link{bs_theme}()},
-\code{\link{bs_theme_dependencies}()},
-\code{\link{bs_theme_preview}()}
+Other Bootstrap theme functions:
+\code{\link[=bs_add_variables]{bs_add_variables()}},
+\code{\link[=bs_dependency]{bs_dependency()}},
+\code{\link[=bs_global_theme]{bs_global_theme()}},
+\code{\link[=bs_remove]{bs_remove()}},
+\code{\link[=bs_theme]{bs_theme()}},
+\code{\link[=bs_theme_dependencies]{bs_theme_dependencies()}},
+\code{\link[=bs_theme_preview]{bs_theme_preview()}}
 }
 \concept{Bootstrap theme functions}

--- a/man/bs_dependency.Rd
+++ b/man/bs_dependency.Rd
@@ -127,13 +127,13 @@ gives a tutorial on creating a dynamically themable custom component.
 }
 }
 \seealso{
-Other Bootstrap theme functions: 
-\code{\link{bs_add_variables}()},
-\code{\link{bs_current_theme}()},
-\code{\link{bs_global_theme}()},
-\code{\link{bs_remove}()},
-\code{\link{bs_theme}()},
-\code{\link{bs_theme_dependencies}()},
-\code{\link{bs_theme_preview}()}
+Other Bootstrap theme functions:
+\code{\link[=bs_add_variables]{bs_add_variables()}},
+\code{\link[=bs_current_theme]{bs_current_theme()}},
+\code{\link[=bs_global_theme]{bs_global_theme()}},
+\code{\link[=bs_remove]{bs_remove()}},
+\code{\link[=bs_theme]{bs_theme()}},
+\code{\link[=bs_theme_dependencies]{bs_theme_dependencies()}},
+\code{\link[=bs_theme_preview]{bs_theme_preview()}}
 }
 \concept{Bootstrap theme functions}

--- a/man/bs_get_variables.Rd
+++ b/man/bs_get_variables.Rd
@@ -45,11 +45,11 @@ provides a searchable reference of all theming variables available in
 Bootstrap 5.
 }
 \seealso{
-Other Bootstrap theme utility functions: 
-\code{\link{bootswatch_themes}()},
-\code{\link{builtin_themes}()},
-\code{\link{theme_bootswatch}()},
-\code{\link{theme_version}()},
-\code{\link{versions}()}
+Other Bootstrap theme utility functions:
+\code{\link[=bootswatch_themes]{bootswatch_themes()}},
+\code{\link[=builtin_themes]{builtin_themes()}},
+\code{\link[=theme_bootswatch]{theme_bootswatch()}},
+\code{\link[=theme_version]{theme_version()}},
+\code{\link[=versions]{versions()}}
 }
 \concept{Bootstrap theme utility functions}

--- a/man/bs_global_theme.Rd
+++ b/man/bs_global_theme.Rd
@@ -151,13 +151,13 @@ bs_global_set(theme)
 
 }
 \seealso{
-Other Bootstrap theme functions: 
-\code{\link{bs_add_variables}()},
-\code{\link{bs_current_theme}()},
-\code{\link{bs_dependency}()},
-\code{\link{bs_remove}()},
-\code{\link{bs_theme}()},
-\code{\link{bs_theme_dependencies}()},
-\code{\link{bs_theme_preview}()}
+Other Bootstrap theme functions:
+\code{\link[=bs_add_variables]{bs_add_variables()}},
+\code{\link[=bs_current_theme]{bs_current_theme()}},
+\code{\link[=bs_dependency]{bs_dependency()}},
+\code{\link[=bs_remove]{bs_remove()}},
+\code{\link[=bs_theme]{bs_theme()}},
+\code{\link[=bs_theme_dependencies]{bs_theme_dependencies()}},
+\code{\link[=bs_theme_preview]{bs_theme_preview()}}
 }
 \concept{Bootstrap theme functions}

--- a/man/bs_remove.Rd
+++ b/man/bs_remove.Rd
@@ -43,13 +43,13 @@ suppressWarnings(
 bs4_no_compat <- bs_remove(bs4, "bs3compat")
 }
 \seealso{
-Other Bootstrap theme functions: 
-\code{\link{bs_add_variables}()},
-\code{\link{bs_current_theme}()},
-\code{\link{bs_dependency}()},
-\code{\link{bs_global_theme}()},
-\code{\link{bs_theme}()},
-\code{\link{bs_theme_dependencies}()},
-\code{\link{bs_theme_preview}()}
+Other Bootstrap theme functions:
+\code{\link[=bs_add_variables]{bs_add_variables()}},
+\code{\link[=bs_current_theme]{bs_current_theme()}},
+\code{\link[=bs_dependency]{bs_dependency()}},
+\code{\link[=bs_global_theme]{bs_global_theme()}},
+\code{\link[=bs_theme]{bs_theme()}},
+\code{\link[=bs_theme_dependencies]{bs_theme_dependencies()}},
+\code{\link[=bs_theme_preview]{bs_theme_preview()}}
 }
 \concept{Bootstrap theme functions}

--- a/man/bs_theme.Rd
+++ b/man/bs_theme.Rd
@@ -130,7 +130,7 @@ Bootswatch theme is first removed before the new one is applied (use
 \item{x}{an object.}
 }
 \value{
-Returns a \code{\link[sass:sass_layer]{sass::sass_bundle()}} (list-like) object.
+Returns a \code{\link[sass:sass_bundle]{sass::sass_bundle()}} (list-like) object.
 }
 \description{
 Creates a Bootstrap theme object, where you can:
@@ -234,13 +234,13 @@ without writing CSS or customizing your \code{bs_theme()}.
 }
 }
 \seealso{
-Other Bootstrap theme functions: 
-\code{\link{bs_add_variables}()},
-\code{\link{bs_current_theme}()},
-\code{\link{bs_dependency}()},
-\code{\link{bs_global_theme}()},
-\code{\link{bs_remove}()},
-\code{\link{bs_theme_dependencies}()},
-\code{\link{bs_theme_preview}()}
+Other Bootstrap theme functions:
+\code{\link[=bs_add_variables]{bs_add_variables()}},
+\code{\link[=bs_current_theme]{bs_current_theme()}},
+\code{\link[=bs_dependency]{bs_dependency()}},
+\code{\link[=bs_global_theme]{bs_global_theme()}},
+\code{\link[=bs_remove]{bs_remove()}},
+\code{\link[=bs_theme_dependencies]{bs_theme_dependencies()}},
+\code{\link[=bs_theme_preview]{bs_theme_preview()}}
 }
 \concept{Bootstrap theme functions}

--- a/man/bs_theme_dependencies.Rd
+++ b/man/bs_theme_dependencies.Rd
@@ -73,13 +73,13 @@ preview_button(bs_theme(4, bootswatch = "sketchy"))
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other Bootstrap theme functions: 
-\code{\link{bs_add_variables}()},
-\code{\link{bs_current_theme}()},
-\code{\link{bs_dependency}()},
-\code{\link{bs_global_theme}()},
-\code{\link{bs_remove}()},
-\code{\link{bs_theme}()},
-\code{\link{bs_theme_preview}()}
+Other Bootstrap theme functions:
+\code{\link[=bs_add_variables]{bs_add_variables()}},
+\code{\link[=bs_current_theme]{bs_current_theme()}},
+\code{\link[=bs_dependency]{bs_dependency()}},
+\code{\link[=bs_global_theme]{bs_global_theme()}},
+\code{\link[=bs_remove]{bs_remove()}},
+\code{\link[=bs_theme]{bs_theme()}},
+\code{\link[=bs_theme_preview]{bs_theme_preview()}}
 }
 \concept{Bootstrap theme functions}

--- a/man/bs_theme_preview.Rd
+++ b/man/bs_theme_preview.Rd
@@ -38,13 +38,13 @@ bs_theme_preview(theme)
 Use \code{\link[=run_with_themer]{run_with_themer()}} or \code{\link[=bs_themer]{bs_themer()}} to add the theming UI to
 an existing shiny app.
 
-Other Bootstrap theme functions: 
-\code{\link{bs_add_variables}()},
-\code{\link{bs_current_theme}()},
-\code{\link{bs_dependency}()},
-\code{\link{bs_global_theme}()},
-\code{\link{bs_remove}()},
-\code{\link{bs_theme}()},
-\code{\link{bs_theme_dependencies}()}
+Other Bootstrap theme functions:
+\code{\link[=bs_add_variables]{bs_add_variables()}},
+\code{\link[=bs_current_theme]{bs_current_theme()}},
+\code{\link[=bs_dependency]{bs_dependency()}},
+\code{\link[=bs_global_theme]{bs_global_theme()}},
+\code{\link[=bs_remove]{bs_remove()}},
+\code{\link[=bs_theme]{bs_theme()}},
+\code{\link[=bs_theme_dependencies]{bs_theme_dependencies()}}
 }
 \concept{Bootstrap theme functions}

--- a/man/bslib-package.Rd
+++ b/man/bslib-package.Rd
@@ -24,6 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Carson Sievert \email{carson@posit.co} (\href{https://orcid.org/0000-0002-4958-2844}{ORCID})
   \item Joe Cheng \email{joe@posit.co}
   \item Garrick Aden-Buie \email{garrick@posit.co} (\href{https://orcid.org/0000-0002-7111-0077}{ORCID})
 }

--- a/man/builtin_themes.Rd
+++ b/man/builtin_themes.Rd
@@ -19,11 +19,11 @@ Returns a character vector of built-in themes provided by
 Obtain a list of all available built-in \pkg{bslib} themes.
 }
 \seealso{
-Other Bootstrap theme utility functions: 
-\code{\link{bootswatch_themes}()},
-\code{\link{bs_get_variables}()},
-\code{\link{theme_bootswatch}()},
-\code{\link{theme_version}()},
-\code{\link{versions}()}
+Other Bootstrap theme utility functions:
+\code{\link[=bootswatch_themes]{bootswatch_themes()}},
+\code{\link[=bs_get_variables]{bs_get_variables()}},
+\code{\link[=theme_bootswatch]{theme_bootswatch()}},
+\code{\link[=theme_version]{theme_version()}},
+\code{\link[=versions]{versions()}}
 }
 \concept{Bootstrap theme utility functions}

--- a/man/card.Rd
+++ b/man/card.Rd
@@ -17,7 +17,7 @@ card(
 )
 }
 \arguments{
-\item{...}{Unnamed arguments can be any valid child of an \link[htmltools:builder]{htmltools tag} (which includes card items such as \code{\link[=card_body]{card_body()}}.
+\item{...}{Unnamed arguments can be any valid child of an \link[htmltools:tags]{htmltools tag} (which includes card items such as \code{\link[=card_body]{card_body()}}.
 Named arguments become HTML attributes on returned UI element.}
 
 \item{full_screen}{If \code{TRUE}, an icon will appear when hovering over the card
@@ -48,7 +48,7 @@ you can observe the card's full screen state with
 \code{input$my_card_full_screen}.}
 }
 \value{
-A \code{\link[htmltools:builder]{htmltools::div()}} tag.
+A \code{\link[htmltools:div]{htmltools::div()}} tag.
 }
 \description{
 A general purpose container for grouping related UI elements together with a
@@ -100,10 +100,10 @@ or \code{\link[=card_body]{card_body()}}.
 \code{\link[=value_box]{value_box()}} uses \code{\link[=card]{card()}} to highlight a showcase a key piece of
 information.
 
-Other Components: 
-\code{\link{accordion}()},
-\code{\link{popover}()},
-\code{\link{tooltip}()},
-\code{\link{value_box}()}
+Other Components:
+\code{\link[=accordion]{accordion()}},
+\code{\link[=popover]{popover()}},
+\code{\link[=tooltip]{tooltip()}},
+\code{\link[=value_box]{value_box()}}
 }
 \concept{Components}

--- a/man/card_body.Rd
+++ b/man/card_body.Rd
@@ -49,7 +49,7 @@ as.card_item(x)
 is.card_item(x)
 }
 \arguments{
-\item{...}{Unnamed arguments can be any valid child of an \link[htmltools:builder]{htmltools tag}. Named arguments become HTML attributes on returned
+\item{...}{Unnamed arguments can be any valid child of an \link[htmltools:tags]{htmltools tag}. Named arguments become HTML attributes on returned
 UI element.}
 
 \item{fillable}{Whether or not the card item should be a fillable (i.e.
@@ -122,7 +122,7 @@ unable to automatically determine the file type.}
 \item{x}{an object to test (or coerce to) a card item.}
 }
 \value{
-An \code{\link[htmltools:builder]{htmltools::div()}} tag.
+An \code{\link[htmltools:div]{htmltools::div()}} tag.
 }
 \description{
 Components designed to be provided as direct children of a \code{\link[=card]{card()}}. For a

--- a/man/fragments/ex-navset_tab.Rmd
+++ b/man/fragments/ex-navset_tab.Rmd
@@ -20,7 +20,7 @@ This first example creates a simple tabbed navigation container with two tabs.
 The tab name and the content of each tab are specified in the `nav_panel()` calls
 and `navset_tab()` creates the tabbed navigation around these two tabs.
 
-```{r navset_tab-basic, fig.alt = "Screenshot of a basic navset_tab() example."}
+```{r navset_tab-basic, message = FALSE, fig.alt = "Screenshot of a basic navset_tab() example."}
 library(htmltools)
 
 navset_tab(

--- a/man/input_code_editor.Rd
+++ b/man/input_code_editor.Rd
@@ -145,8 +145,8 @@ shinyApp(ui, server)
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other input controls: 
-\code{\link{input_dark_mode}()},
-\code{\link{input_switch}()}
+Other input controls:
+\code{\link[=input_dark_mode]{input_dark_mode()}},
+\code{\link[=input_switch]{input_switch()}}
 }
 \concept{input controls}

--- a/man/input_dark_mode.Rd
+++ b/man/input_dark_mode.Rd
@@ -46,8 +46,8 @@ or dark color mode.
 
 }}
 \seealso{
-Other input controls: 
-\code{\link{input_code_editor}()},
-\code{\link{input_switch}()}
+Other input controls:
+\code{\link[=input_code_editor]{input_code_editor()}},
+\code{\link[=input_switch]{input_switch()}}
 }
 \concept{input controls}

--- a/man/input_submit_textarea.Rd
+++ b/man/input_submit_textarea.Rd
@@ -48,7 +48,7 @@ element (e.g., spellcheck, autocomplete, etc).}
 sets the minimum height -- the textarea can grow taller as the user
 enters more text.}
 
-\item{button}{A \link[htmltools:builder]{htmltools::tags} element to use for the submit button. It's recommended
+\item{button}{A \link[htmltools:tags]{htmltools::tags} element to use for the submit button. It's recommended
 that this be a \code{\link[=input_task_button]{input_task_button()}} since it will automatically provide a
 busy indicator (and disable) until the next flush occurs. Note also that if
 the submit button launches a \link[shiny:ExtendedTask]{shiny::ExtendedTask}, this button can also be bound

--- a/man/input_switch.Rd
+++ b/man/input_switch.Rd
@@ -64,8 +64,8 @@ shinyApp(ui, server)
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other input controls: 
-\code{\link{input_code_editor}()},
-\code{\link{input_dark_mode}()}
+Other input controls:
+\code{\link[=input_code_editor]{input_code_editor()}},
+\code{\link[=input_dark_mode]{input_dark_mode()}}
 }
 \concept{input controls}

--- a/man/input_task_button.Rd
+++ b/man/input_task_button.Rd
@@ -59,7 +59,7 @@ in "ready" state after its click is handled by the server.}
 }
 \description{
 \code{input_task_button} is a button that can be used in conjuction with
-\code{\link[shiny:bindEvent]{shiny::bindEvent()}} (or the older \code{\link[shiny:observeEvent]{shiny::eventReactive()}} and
+\code{\link[shiny:bindEvent]{shiny::bindEvent()}} (or the older \code{\link[shiny:eventReactive]{shiny::eventReactive()}} and
 \code{\link[shiny:observeEvent]{shiny::observeEvent()}} functions) to trigger actions or recomputation.
 
 It is similar to \code{\link[shiny:actionButton]{shiny::actionButton()}}, except it prevents the user from
@@ -100,7 +100,7 @@ The task button is designed to automatically switch between two states: the
 \code{label_busy} and \code{icon_busy}.
 
 In advanced use cases, you can include additional states by adding an
-\code{\link[htmltools:builder]{htmltools::div()}} with a \code{slot} attribute naming the state and the icon and
+\code{\link[htmltools:div]{htmltools::div()}} with a \code{slot} attribute naming the state and the icon and
 label as the first and second children, respectively.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{input_task_button(
@@ -127,9 +127,9 @@ An integer of class \code{"shinyActionButtonValue"}. This class differs from
 ordinary integers in that a value of 0 is considered "falsy". This implies
 two things:
 \itemize{
-\item Event handlers (e.g., \code{\link[shiny:observeEvent]{shiny::observeEvent()}}, \code{\link[shiny:observeEvent]{shiny::eventReactive()}})
+\item Event handlers (e.g., \code{\link[shiny:observeEvent]{shiny::observeEvent()}}, \code{\link[shiny:eventReactive]{shiny::eventReactive()}})
 won't execute on initial load.
-\item Input validation (e.g., \code{\link[shiny:req]{shiny::req()}}, \code{\link[shiny:validate]{shiny::need()}}) will fail on
+\item Input validation (e.g., \code{\link[shiny:req]{shiny::req()}}, \code{\link[shiny:need]{shiny::need()}}) will fail on
 initial load.
 }
 }

--- a/man/layout_column_wrap.Rd
+++ b/man/layout_column_wrap.Rd
@@ -21,7 +21,7 @@ layout_column_wrap(
 }
 \arguments{
 \item{...}{Unnamed arguments should be UI elements (e.g., \code{\link[=card]{card()}}). Named
-arguments become attributes on the containing \link[htmltools:builder]{htmltools::tag} element.}
+arguments become attributes on the containing \link[htmltools:tag]{htmltools::tag} element.}
 
 \item{width}{The desired width of each card, which can be any of the
 following:
@@ -111,7 +111,7 @@ The bslib website features \code{layout_column_wrap()} in two places:
 }
 }
 \seealso{
-Other Column layouts: 
-\code{\link{layout_columns}()}
+Other Column layouts:
+\code{\link[=layout_columns]{layout_columns()}}
 }
 \concept{Column layouts}

--- a/man/layout_columns.Rd
+++ b/man/layout_columns.Rd
@@ -19,7 +19,7 @@ layout_columns(
 }
 \arguments{
 \item{...}{Unnamed arguments should be UI elements (e.g., \code{\link[=card]{card()}}). Named
-arguments become attributes on the containing \link[htmltools:builder]{htmltools::tag} element.}
+arguments become attributes on the containing \link[htmltools:tag]{htmltools::tag} element.}
 
 \item{col_widths}{One of the following:
 \itemize{
@@ -126,7 +126,7 @@ on the bslib website.
 \code{\link[=breakpoints]{breakpoints()}} for more information on specifying column widths at
 responsive breakpoints.
 
-Other Column layouts: 
-\code{\link{layout_column_wrap}()}
+Other Column layouts:
+\code{\link[=layout_column_wrap]{layout_column_wrap()}}
 }
 \concept{Column layouts}

--- a/man/nav-items.Rd
+++ b/man/nav-items.Rd
@@ -21,15 +21,15 @@ nav_spacer()
 }
 \arguments{
 \item{title}{A title to display. Can be a character string or UI elements
-(i.e., \link[htmltools:builder]{htmltools::tags}).}
+(i.e., \link[htmltools:tags]{htmltools::tags}).}
 
 \item{...}{Depends on the function:
 \itemize{
 \item For \code{nav_panel()} and \code{nav_panel_hidden()}: UI elements (i.e.,
-\link[htmltools:builder]{htmltools::tags}) to display when the item is active.
+\link[htmltools:tags]{htmltools::tags}) to display when the item is active.
 \item For \code{nav_menu()}: a collection of nav items (e.g., \code{nav_panel()},
 \code{nav_item()}).
-\item For \code{nav_item()}: UI elements (i.e., \link[htmltools:builder]{htmltools::tags}) to place directly in
+\item For \code{nav_item()}: UI elements (i.e., \link[htmltools:tags]{htmltools::tags}) to place directly in
 the navigation panel (e.g., search forms, links to external content, etc).
 }}
 
@@ -80,8 +80,8 @@ panels.
 \code{\link[=nav_select]{nav_select()}}, \code{\link[=nav_show]{nav_show()}}, \code{\link[=nav_hide]{nav_hide()}} change the state of a
 \code{\link[=nav_panel]{nav_panel()}} in a navset.
 
-Other Panel container functions: 
-\code{\link{nav_select}()},
+Other Panel container functions:
+\code{\link[=nav_select]{nav_select()}},
 \code{\link{navset}}
 }
 \concept{Panel container functions}

--- a/man/nav_prepend.Rd
+++ b/man/nav_prepend.Rd
@@ -34,7 +34,7 @@ nav_append(
 used).}
 }
 \description{
-Exported for use by \code{\link[shiny:insertTab]{shiny::prependTab()}}/\code{\link[shiny:insertTab]{shiny::appendTab()}}. These
+Exported for use by \code{\link[shiny:prependTab]{shiny::prependTab()}}/\code{\link[shiny:appendTab]{shiny::appendTab()}}. These
 functions have been superseded by \code{\link[=nav_insert]{nav_insert()}} (i.e.,
 \code{\link[shiny:insertTab]{shiny::insertTab()}}), since it can do everything these functions do (i.e.,
 add a \code{\link[=nav_panel]{nav_panel()}} to the start or end of a \code{\link[=nav_menu]{nav_menu()}}) and more (i.e., insert a

--- a/man/nav_select.Rd
+++ b/man/nav_select.Rd
@@ -104,7 +104,7 @@ the nav panels.
 \code{\link[=nav_menu]{nav_menu()}}, \code{\link[=nav_item]{nav_item()}}, \code{\link[=nav_spacer]{nav_spacer()}} create menus, items, or
 space in the navset control area.
 
-Other Panel container functions: 
+Other Panel container functions:
 \code{\link{nav-items}},
 \code{\link{navset}}
 }

--- a/man/navbar_options.Rd
+++ b/man/navbar_options.Rd
@@ -23,7 +23,7 @@ the top (\code{"fixed-top"}), or pinned at the bottom
 (\code{"fixed-bottom"}). Note that using \code{"fixed-top"} or
 \code{"fixed-bottom"} will cause the navbar to overlay your body content,
 unless you add padding, e.g.: \code{tags$style(type="text/css", "body
-  {padding-top: 70px;}")}}
+{padding-top: 70px;}")}}
 
 \item{bg}{a CSS color to use for the navbar's background color.}
 

--- a/man/navset.Rd
+++ b/man/navset.Rd
@@ -100,12 +100,12 @@ navset_card_underline(
 \item{selected}{a character string matching the \code{value} of a particular
 \code{\link[=nav_panel]{nav_panel()}} item to selected by default.}
 
-\item{header}{UI element(s) (\link[htmltools:builder]{htmltools::tags}) to display \emph{above} the nav
+\item{header}{UI element(s) (\link[htmltools:tags]{htmltools::tags}) to display \emph{above} the nav
 content. For \code{card}-based navsets, these elements are implicitly wrapped in
 a \code{card_body()}. To control things like \code{padding}, \code{fill}, etc., wrap the
 elements in an explicit \code{\link[=card_body]{card_body()}}.}
 
-\item{footer}{UI element(s) (\link[htmltools:builder]{htmltools::tags}) to display \emph{below} the nav
+\item{footer}{UI element(s) (\link[htmltools:tags]{htmltools::tags}) to display \emph{below} the nav
 content. For \code{card}-based navsets, these elements are implicitly wrapped in
 a \code{card_body()}. To control things like \code{padding}, \code{fill}, etc., wrap the
 elements in an explicit \code{\link[=card_body]{card_body()}}.}
@@ -185,6 +185,7 @@ The tab name and the content of each tab are specified in the \code{nav_panel()}
 and \code{navset_tab()} creates the tabbed navigation around these two tabs.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{library(htmltools)
+#> Warning: package 'htmltools' was built under R version 4.5.2
 
 navset_tab(
   nav_panel(title = "One", p("First tab content.")),
@@ -404,8 +405,8 @@ panels.
 \code{\link[=nav_select]{nav_select()}}, \code{\link[=nav_show]{nav_show()}}, \code{\link[=nav_hide]{nav_hide()}} change the state of a
 \code{\link[=nav_panel]{nav_panel()}} in a navset.
 
-Other Panel container functions: 
+Other Panel container functions:
 \code{\link{nav-items}},
-\code{\link{nav_select}()}
+\code{\link[=nav_select]{nav_select()}}
 }
 \concept{Panel container functions}

--- a/man/page_fillable.Rd
+++ b/man/page_fillable.Rd
@@ -124,8 +124,8 @@ into rows and columns.
 
 \code{\link[=value_box]{value_box()}} for highlighting values.
 
-Other Dashboard page layouts: 
-\code{\link{page_navbar}()},
-\code{\link{page_sidebar}()}
+Other Dashboard page layouts:
+\code{\link[=page_navbar]{page_navbar()}},
+\code{\link[=page_sidebar]{page_sidebar()}}
 }
 \concept{Dashboard page layouts}

--- a/man/page_navbar.Rd
+++ b/man/page_navbar.Rd
@@ -64,12 +64,12 @@ right. If three, then the first will be used for top, the second will be
 left and right, and the third will be bottom. If four, then the values will
 be interpreted as top, right, bottom, and left respectively.}
 
-\item{header}{UI element(s) (\link[htmltools:builder]{htmltools::tags}) to display \emph{above} the nav
+\item{header}{UI element(s) (\link[htmltools:tags]{htmltools::tags}) to display \emph{above} the nav
 content. For \code{card}-based navsets, these elements are implicitly wrapped in
 a \code{card_body()}. To control things like \code{padding}, \code{fill}, etc., wrap the
 elements in an explicit \code{\link[=card_body]{card_body()}}.}
 
-\item{footer}{UI element(s) (\link[htmltools:builder]{htmltools::tags}) to display \emph{below} the nav
+\item{footer}{UI element(s) (\link[htmltools:tags]{htmltools::tags}) to display \emph{below} the nav
 content. For \code{card}-based navsets, these elements are implicitly wrapped in
 a \code{card_body()}. To control things like \code{padding}, \code{fill}, etc., wrap the
 elements in an explicit \code{\link[=card_body]{card_body()}}.}
@@ -163,8 +163,8 @@ into rows and columns.
 
 \code{\link[=accordion]{accordion()}} for grouping related input controls in the \code{sidebar}.
 
-Other Dashboard page layouts: 
-\code{\link{page_fillable}()},
-\code{\link{page_sidebar}()}
+Other Dashboard page layouts:
+\code{\link[=page_fillable]{page_fillable()}},
+\code{\link[=page_sidebar]{page_sidebar()}}
 }
 \concept{Dashboard page layouts}

--- a/man/page_sidebar.Rd
+++ b/man/page_sidebar.Rd
@@ -22,7 +22,7 @@ more details.}
 
 \item{sidebar}{A \code{\link[=sidebar]{sidebar()}} object.}
 
-\item{title}{A string, number, or \code{\link[htmltools:builder]{htmltools::tag()}} child to display as the
+\item{title}{A string, number, or \code{\link[htmltools:tag]{htmltools::tag()}} child to display as the
 title (just above the \code{sidebar}).}
 
 \item{fillable}{Whether or not the \code{main} content area should be considered a
@@ -86,8 +86,8 @@ into rows and columns.
 
 \code{\link[=value_box]{value_box()}} for highlighting values.
 
-Other Dashboard page layouts: 
-\code{\link{page_fillable}()},
-\code{\link{page_navbar}()}
+Other Dashboard page layouts:
+\code{\link[=page_fillable]{page_fillable()}},
+\code{\link[=page_navbar]{page_navbar()}}
 }
 \concept{Dashboard page layouts}

--- a/man/popover.Rd
+++ b/man/popover.Rd
@@ -24,7 +24,7 @@ update_popover(id, ..., title = NULL, session = get_current_session())
 \code{\link[shiny:actionButton]{shiny::actionButton()}} or similar). If \code{trigger} renders as multiple HTML
 elements (e.g., it's a \code{tagList()}), the last HTML element is used for the
 trigger. If the \code{trigger} should contain all of those elements, wrap the
-object in a \code{\link[htmltools:builder]{htmltools::div()}} or \code{\link[htmltools:builder]{htmltools::span()}}.}
+object in a \code{\link[htmltools:div]{htmltools::div()}} or \code{\link[htmltools:span]{htmltools::span()}}.}
 
 \item{...}{UI elements for the popover's body. Character strings are
 \link[htmltools:htmlEscape]{automatically escaped} unless marked as
@@ -169,10 +169,10 @@ bslib website for an \href{https://rstudio.github.io/bslib/articles/tooltips-pop
 \code{\link[=tooltip]{tooltip()}} provides an alternative way to display informational
 text on demand, typically when focusing or hovering over a trigger element.
 
-Other Components: 
-\code{\link{accordion}()},
-\code{\link{card}()},
-\code{\link{tooltip}()},
-\code{\link{value_box}()}
+Other Components:
+\code{\link[=accordion]{accordion()}},
+\code{\link[=card]{card()}},
+\code{\link[=tooltip]{tooltip()}},
+\code{\link[=value_box]{value_box()}}
 }
 \concept{Components}

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -11,6 +11,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{htmltools}{\code{\link[htmltools]{css}}}
+  \item{htmltools}{\code{\link[htmltools:css]{css()}}}
 }}
 

--- a/man/show_toast.Rd
+++ b/man/show_toast.Rd
@@ -68,7 +68,7 @@ shinyApp(ui, server)
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other Toast components: 
-\code{\link{toast}()}
+Other Toast components:
+\code{\link[=toast]{toast()}}
 }
 \concept{Toast components}

--- a/man/sidebar.Rd
+++ b/man/sidebar.Rd
@@ -41,7 +41,7 @@ layout_sidebar(
 toggle_sidebar(id, open = NULL, session = get_current_session())
 }
 \arguments{
-\item{...}{Unnamed arguments can be any valid child of an \link[htmltools:builder]{htmltools tag} and named arguments become HTML attributes on
+\item{...}{Unnamed arguments can be any valid child of an \link[htmltools:tags]{htmltools tag} and named arguments become HTML attributes on
 returned UI element. In the case of \code{layout_sidebar()}, these arguments are
 passed to the main content tag (not the sidebar+main content container).}
 
@@ -79,7 +79,7 @@ update) the \code{collapsible} state in a Shiny app.}
 
 \item{title}{A character title to be used as the sidebar title, which will be
 wrapped in a \verb{<header>} element with class \code{sidebar-title}. You can also
-provide a custom \code{\link[htmltools:builder]{htmltools::tag()}} for the title element, in which case
+provide a custom \code{\link[htmltools:tag]{htmltools::tag()}} for the title element, in which case
 you'll likely want to give this element \code{class = "sidebar-title"}.}
 
 \item{bg, fg}{A background or foreground color. If only one of either is

--- a/man/theme_bootswatch.Rd
+++ b/man/theme_bootswatch.Rd
@@ -16,11 +16,11 @@ Returns the Bootswatch theme named used (if any) in the \code{theme}.
 Obtain a theme's Bootswatch theme name
 }
 \seealso{
-Other Bootstrap theme utility functions: 
-\code{\link{bootswatch_themes}()},
-\code{\link{bs_get_variables}()},
-\code{\link{builtin_themes}()},
-\code{\link{theme_version}()},
-\code{\link{versions}()}
+Other Bootstrap theme utility functions:
+\code{\link[=bootswatch_themes]{bootswatch_themes()}},
+\code{\link[=bs_get_variables]{bs_get_variables()}},
+\code{\link[=builtin_themes]{builtin_themes()}},
+\code{\link[=theme_version]{theme_version()}},
+\code{\link[=versions]{versions()}}
 }
 \concept{Bootstrap theme utility functions}

--- a/man/theme_version.Rd
+++ b/man/theme_version.Rd
@@ -16,11 +16,11 @@ Returns the major version of Bootstrap used in the \code{theme}.
 Obtain a theme's Bootstrap version
 }
 \seealso{
-Other Bootstrap theme utility functions: 
-\code{\link{bootswatch_themes}()},
-\code{\link{bs_get_variables}()},
-\code{\link{builtin_themes}()},
-\code{\link{theme_bootswatch}()},
-\code{\link{versions}()}
+Other Bootstrap theme utility functions:
+\code{\link[=bootswatch_themes]{bootswatch_themes()}},
+\code{\link[=bs_get_variables]{bs_get_variables()}},
+\code{\link[=builtin_themes]{builtin_themes()}},
+\code{\link[=theme_bootswatch]{theme_bootswatch()}},
+\code{\link[=versions]{versions()}}
 }
 \concept{Bootstrap theme utility functions}

--- a/man/toast.Rd
+++ b/man/toast.Rd
@@ -136,7 +136,7 @@ shinyApp(ui, server)
 \code{\link[=show_toast]{show_toast()}} to display a toast, \code{\link[=hide_toast]{hide_toast()}} to dismiss a
 toast, and \code{\link[=toast_header]{toast_header()}} to create structured headers.
 
-Other Toast components: 
-\code{\link{show_toast}()}
+Other Toast components:
+\code{\link[=show_toast]{show_toast()}}
 }
 \concept{Toast components}

--- a/man/toolbar.Rd
+++ b/man/toolbar.Rd
@@ -251,9 +251,9 @@ shinyApp(ui, server)
 \seealso{
 \code{\link[=card_header]{card_header()}} for using toolbars in card headers/footers
 
-Other toolbar components: 
-\code{\link{toolbar_divider}()},
-\code{\link{toolbar_input_button}()},
-\code{\link{toolbar_input_select}()}
+Other toolbar components:
+\code{\link[=toolbar_divider]{toolbar_divider()}},
+\code{\link[=toolbar_input_button]{toolbar_input_button()}},
+\code{\link[=toolbar_input_select]{toolbar_input_select()}}
 }
 \concept{toolbar components}

--- a/man/toolbar_divider.Rd
+++ b/man/toolbar_divider.Rd
@@ -60,9 +60,9 @@ toolbar(
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other toolbar components: 
-\code{\link{toolbar}()},
-\code{\link{toolbar_input_button}()},
-\code{\link{toolbar_input_select}()}
+Other toolbar components:
+\code{\link[=toolbar]{toolbar()}},
+\code{\link[=toolbar_input_button]{toolbar_input_button()}},
+\code{\link[=toolbar_input_select]{toolbar_input_select()}}
 }
 \concept{toolbar components}

--- a/man/toolbar_input_button.Rd
+++ b/man/toolbar_input_button.Rd
@@ -164,9 +164,9 @@ toolbar(
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other toolbar components: 
-\code{\link{toolbar}()},
-\code{\link{toolbar_divider}()},
-\code{\link{toolbar_input_select}()}
+Other toolbar components:
+\code{\link[=toolbar]{toolbar()}},
+\code{\link[=toolbar_divider]{toolbar_divider()}},
+\code{\link[=toolbar_input_select]{toolbar_input_select()}}
 }
 \concept{toolbar components}

--- a/man/toolbar_input_select.Rd
+++ b/man/toolbar_input_select.Rd
@@ -164,9 +164,9 @@ toolbar(
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other toolbar components: 
-\code{\link{toolbar}()},
-\code{\link{toolbar_divider}()},
-\code{\link{toolbar_input_button}()}
+Other toolbar components:
+\code{\link[=toolbar]{toolbar()}},
+\code{\link[=toolbar_divider]{toolbar_divider()}},
+\code{\link[=toolbar_input_button]{toolbar_input_button()}}
 }
 \concept{toolbar components}

--- a/man/tooltip.Rd
+++ b/man/tooltip.Rd
@@ -19,11 +19,11 @@ toggle_tooltip(id, show = NULL, session = get_current_session())
 update_tooltip(id, ..., session = get_current_session())
 }
 \arguments{
-\item{trigger}{A UI element (i.e., \link[htmltools:builder]{htmltools tag}) to serve
+\item{trigger}{A UI element (i.e., \link[htmltools:tags]{htmltools tag}) to serve
 as the tooltip trigger. If \code{trigger} renders as multiple HTML
 elements (e.g., it's a \code{tagList()}), the last HTML element is used for the
 trigger. If the \code{trigger} should contain all of those elements, wrap the
-object in a \code{\link[htmltools:builder]{htmltools::div()}} or \code{\link[htmltools:builder]{htmltools::span()}}.}
+object in a \code{\link[htmltools:div]{htmltools::div()}} or \code{\link[htmltools:span]{htmltools::span()}}.}
 
 \item{...}{UI elements for the tooltip. Character strings are \link[htmltools:htmlEscape]{automatically escaped} unless marked as \code{\link[htmltools:HTML]{htmltools::HTML()}}.
 Tooltip content should expand on, not contradict element labels.}
@@ -137,10 +137,10 @@ bslib website for an \href{https://rstudio.github.io/bslib/articles/tooltips-pop
 for additional elements, typically revealed by clicking on a target
 element.
 
-Other Components: 
-\code{\link{accordion}()},
-\code{\link{card}()},
-\code{\link{popover}()},
-\code{\link{value_box}()}
+Other Components:
+\code{\link[=accordion]{accordion()}},
+\code{\link[=card]{card()}},
+\code{\link[=popover]{popover()}},
+\code{\link[=value_box]{value_box()}}
 }
 \concept{Components}

--- a/man/value_box.Rd
+++ b/man/value_box.Rd
@@ -51,14 +51,14 @@ showcase_bottom(
 )
 }
 \arguments{
-\item{title, value}{A string, number, or \code{\link[htmltools:builder]{htmltools::tag()}} child to display as
+\item{title, value}{A string, number, or \code{\link[htmltools:tag]{htmltools::tag()}} child to display as
 the title or value of the value box. The \code{title} appears above the \code{value}.}
 
-\item{...}{Unnamed arguments may be any \code{\link[htmltools:builder]{htmltools::tag()}} children to
+\item{...}{Unnamed arguments may be any \code{\link[htmltools:tag]{htmltools::tag()}} children to
 display below \code{value}. Named arguments become attributes on the containing
 element.}
 
-\item{showcase}{A \code{\link[htmltools:builder]{htmltools::tag()}} child to showcase (e.g., a
+\item{showcase}{A \code{\link[htmltools:tag]{htmltools::tag()}} child to showcase (e.g., a
 \code{\link[bsicons:bs_icon]{bsicons::bs_icon()}}, a \code{plotly::plotlyOutput()}, etc).}
 
 \item{showcase_layout}{One of \code{"left center"} (default), \code{"top right"} or
@@ -403,10 +403,10 @@ Value boxes are a specialized form of a \code{\link[=card]{card()}} component.
 \code{\link[=layout_columns]{layout_columns()}} and \code{\link[=layout_column_wrap]{layout_column_wrap()}} help position multiple
 value boxes into columns and rows.
 
-Other Components: 
-\code{\link{accordion}()},
-\code{\link{card}()},
-\code{\link{popover}()},
-\code{\link{tooltip}()}
+Other Components:
+\code{\link[=accordion]{accordion()}},
+\code{\link[=card]{card()}},
+\code{\link[=popover]{popover()}},
+\code{\link[=tooltip]{tooltip()}}
 }
 \concept{Components}

--- a/man/versions.Rd
+++ b/man/versions.Rd
@@ -16,11 +16,11 @@ Returns a list of the Bootstrap versions available.
 Available Bootstrap versions
 }
 \seealso{
-Other Bootstrap theme utility functions: 
-\code{\link{bootswatch_themes}()},
-\code{\link{bs_get_variables}()},
-\code{\link{builtin_themes}()},
-\code{\link{theme_bootswatch}()},
-\code{\link{theme_version}()}
+Other Bootstrap theme utility functions:
+\code{\link[=bootswatch_themes]{bootswatch_themes()}},
+\code{\link[=bs_get_variables]{bs_get_variables()}},
+\code{\link[=builtin_themes]{builtin_themes()}},
+\code{\link[=theme_bootswatch]{theme_bootswatch()}},
+\code{\link[=theme_version]{theme_version()}}
 }
 \concept{Bootstrap theme utility functions}


### PR DESCRIPTION
Pipeline Roxygen2 has updated to 8.0.0. This updates the current documentation to that format.

- [x] Checked to make sure site still renders properly

Doing this in a separate PR so as not to clutter the diffs of the current ones.

Note: Failure in routine is due to an issue with stringr (used to be installed as a transitory dependency, not anymore) and will be addressed in a separate PR.